### PR TITLE
Fix RSA signature verification by hex decoding signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
  "clap",
  "dirs",
  "flate2",
+ "hex",
  "prost",
  "rand",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }
 tonic = "0.11"
 uuid = { version = "1.8", features = ["v7"] }
 walkdir = "2.5"
+hex = "0.4.3"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       in {
         packages = {
           default = buildRustPackage {
-            cargoSha256 = "sha256-llvbfjVZbrPkWEdIpPJEYLm++HxwN7WypUeZ/RrZtZw=";
+            cargoSha256 = "sha256-ajINMwlrYWUsmvrFbIENn8P4JRKqo9ggvn6Mpgz1bfk=";
             nativeBuildInputs = [protobuf];
             pname = "vorpal";
             src = ./.;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -45,7 +45,14 @@ impl PackageService for Packager {
         };
         let verifying_key = VerifyingKey::<Sha256>::new(public_key);
 
-        let source_signature = match Signature::try_from(message.source_signature.as_bytes()) {
+        let dehexed_source_signature = match hex::decode(&message.source_signature) {
+            Ok(data) => {
+                data
+            }
+            Err(_) => {return Err(Status::internal("hex decode of signature failed"))}
+        };
+
+        let source_signature = match Signature::try_from(dehexed_source_signature.as_slice()) {
             Ok(signature) => signature,
             Err(e) => {
                 eprintln!("Failed to decode signature: {:?}", e);


### PR DESCRIPTION
Fix RSA signature verification by hex decoding signatures

- Added `hex` dependency to `Cargo.toml` and `Cargo.lock` for hex decoding
- Updated `src/service/mod.rs` to decode hex-encoded signatures before verification