### PR TITLE
Add tracing and converting all printlns to info logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1310,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1867,6 +1883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2058,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -2225,6 +2260,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2344,6 +2405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,6 +2447,8 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "walkdir",
@@ -2487,6 +2556,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2579,12 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ tonic = "0.11"
 url = "2.5"
 uuid = { version = "1.8", features = ["v7"] }
 walkdir = "2.5"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
         packages = {
           default = buildRustPackage {
             buildInputs = [openssl] ++ lib.optionals pkgs.stdenv.isDarwin [CoreServices SystemConfiguration Security];
-            cargoSha256 = "sha256-aBfWKqOlRxAOSkRoL+vX4mCbz6jZ7+XVp3uHwS8N4TY=";
+            cargoSha256 = "sha256-FliwadZfdF0+O3BRTbaR1nks8SmIDIi6I2dV9iyTZFw=";
             checkPhase = ''
               ${pkgs.cargo}/bin/cargo clippy -- -D warnings
               ${pkgs.rust-bin.nightly.latest.default}/bin/cargo fmt --check --verbose

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -3,7 +3,6 @@ use crate::service::proxy;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing::Level;
-use tracing_subscriber::layer::SubscriberExt;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,11 +2,16 @@ use crate::service::build;
 use crate::service::proxy;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use tracing::Level;
+use tracing_subscriber::layer::SubscriberExt;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
 pub struct Cli {
+    #[clap(long, global = true, default_value_t = Level::INFO)]
+    pub level: tracing::Level,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -44,6 +49,16 @@ pub enum Proxy {
 
 pub async fn run() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();
+
+    let mut subscriber = tracing_subscriber::FmtSubscriber::builder().with_max_level(cli.level);
+
+    // when we run the command with `TRACE` or `DEBUG` level, we want to see
+    // the file and line number...
+    if [Level::DEBUG, Level::TRACE].contains(&cli.level) {
+        subscriber = subscriber.with_file(true).with_line_number(true);
+    }
+    let subscriber = subscriber.finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber");
 
     match &cli.command {
         Command::Service(service) => match service {

--- a/src/notary/mod.rs
+++ b/src/notary/mod.rs
@@ -8,6 +8,7 @@ use rsa::sha2::Sha256;
 use rsa::signature::RandomizedSigner;
 use rsa::{RsaPrivateKey, RsaPublicKey};
 use tokio::fs;
+use tracing::debug;
 
 pub fn generate_keys() -> Result<(), anyhow::Error> {
     let mut rng = rand::thread_rng();
@@ -18,13 +19,13 @@ pub fn generate_keys() -> Result<(), anyhow::Error> {
     let private_key_der = private_key.to_pkcs8_der()?;
     private_key_der.write_pem_file(&private_key_path, "PRIVATE KEY", LineEnding::LF)?;
 
-    println!("Private key generated: {}", private_key_path.display());
+    debug!("private key generated: {:?}", private_key_path);
 
     let public_key_path = store::get_public_key_path();
     let public_key = private_key.to_public_key();
     public_key.write_public_key_pem_file(&public_key_path, LineEnding::LF)?;
 
-    println!("Public key generated: {}", public_key_path.display());
+    debug!("public key generated: {:?}", public_key_path);
 
     Ok(())
 }

--- a/src/service/build/mod.rs
+++ b/src/service/build/mod.rs
@@ -5,6 +5,7 @@ use crate::store;
 use anyhow::Result;
 use tokio::fs;
 use tonic::transport::Server;
+use tracing::info;
 
 mod run_build;
 mod run_prepare;
@@ -17,26 +18,26 @@ pub async fn start(port: u16) -> Result<(), anyhow::Error> {
         fs::create_dir_all(&vorpal_dir).await?;
     }
 
-    println!("Vorpal directory: {:?}", vorpal_dir);
+    info!("resolved vorpal directory: {}", vorpal_dir.display());
 
     let store_dir = store::get_store_dir_path();
     if !store_dir.exists() {
         fs::create_dir_all(&store_dir).await?;
     }
 
-    println!("Store directory: {:?}", store_dir);
+    info!("Store directory: {:?}", store_dir);
 
     let private_key_path = store::get_private_key_path();
     let public_key_path = store::get_public_key_path();
     if !private_key_path.exists() && !public_key_path.exists() {
         let key_dir = store::get_private_key_path();
         fs::create_dir_all(&key_dir).await?;
-        println!("Key directory: {:?}", key_dir);
+        info!("Key directory: {:?}", key_dir);
         notary::generate_keys()?;
     }
 
-    println!("Private key: {:?}", private_key_path);
-    println!("Public key: {:?}", public_key_path);
+    info!("Private key: {:?}", private_key_path);
+    info!("Public key: {:?}", public_key_path);
 
     let db_path = store::get_database_path();
     let db = database::connect(db_path.clone())?;
@@ -50,7 +51,7 @@ pub async fn start(port: u16) -> Result<(), anyhow::Error> {
         [],
     )?;
 
-    println!("Database path: {:?}", db_path.display());
+    info!("Database path: {:?}", db_path.display());
 
     match db.close() {
         Ok(_) => (),
@@ -60,7 +61,7 @@ pub async fn start(port: u16) -> Result<(), anyhow::Error> {
     let addr = format!("[::1]:{}", port).parse()?;
     let packager = service::Package::default();
 
-    println!("Build listening on: {}", addr);
+    info!("Build listening on: {}", addr);
 
     Server::builder()
         .add_service(PackageServiceServer::new(packager))

--- a/src/service/proxy/mod.rs
+++ b/src/service/proxy/mod.rs
@@ -3,6 +3,7 @@ use crate::notary;
 use crate::store;
 use tokio::fs;
 use tonic::transport::Server;
+use tracing::info;
 
 mod package;
 mod service;
@@ -13,26 +14,26 @@ pub async fn start(port: u16) -> Result<(), anyhow::Error> {
         fs::create_dir_all(&vorpal_dir).await?;
     }
 
-    println!("Vorpal directory: {:?}", vorpal_dir);
+    info!("Vorpal directory: {:?}", vorpal_dir);
 
     let store_dir = store::get_store_dir_path();
     if !store_dir.exists() {
         fs::create_dir_all(&store_dir).await?;
     }
 
-    println!("Store directory: {:?}", store_dir);
+    info!("Store directory: {:?}", store_dir);
 
     let private_key_path = store::get_private_key_path();
     let public_key_path = store::get_public_key_path();
     if !private_key_path.exists() && !public_key_path.exists() {
         let key_dir = store::get_private_key_path();
         fs::create_dir_all(&key_dir).await?;
-        println!("Key directory: {:?}", key_dir);
+        info!("Key directory: {:?}", key_dir);
         notary::generate_keys()?;
     }
 
-    println!("Private key: {:?}", private_key_path);
-    println!("Public key: {:?}", public_key_path);
+    info!("Private key: {:?}", private_key_path);
+    info!("Public key: {:?}", public_key_path);
 
     let addr = format!("[::1]:{}", port).parse()?;
     let proxy = service::Proxy::default();

--- a/src/service/proxy/package/mod.rs
+++ b/src/service/proxy/package/mod.rs
@@ -17,27 +17,28 @@ use tokio::fs::{copy, create_dir_all, read, set_permissions, write, File};
 use tokio::io::AsyncWriteExt;
 use tokio_stream;
 use tonic::{Request, Response, Status};
+use tracing::{error, info};
 use url::Url;
 
 pub async fn run(request: Request<PackageRequest>) -> Result<Response<PackageResponse>, Status> {
     let req = request.into_inner();
 
     let req_source = req.source.as_ref().ok_or_else(|| {
-        eprintln!("Source is required");
+        error!("Source is required");
         Status::invalid_argument("Source is required")
     })?;
 
-    println!("Preparing: {}", req.name);
+    info!("Preparing: {}", req.name);
 
     let (source_id, source_hash) = prepare(&req.name, req_source).await.map_err(|e| {
-        eprintln!("Failed to prepare: {:?}", e);
+        error!("Failed to prepare: {:?}", e);
         Status::internal(e.to_string())
     })?;
 
-    println!("Building: {}-{}", req.name, source_hash);
+    info!("Building: {}-{}", req.name, source_hash);
 
     build(source_id, &source_hash, &req).await.map_err(|e| {
-        eprintln!("Failed to build: {:?}", e);
+        error!("Failed to build: {:?}", e);
         Status::internal(e.to_string())
     })?;
 
@@ -58,7 +59,7 @@ async fn prepare_source(
 
     let signature = notary::sign(&data).await?;
 
-    println!("Source tar signature: {}", signature);
+    info!("Source tar signature: {}", signature);
 
     let mut request_chunks = vec![];
     let request_chunks_size = 2 * 1024 * 1024; // default grpc limit
@@ -72,13 +73,13 @@ async fn prepare_source(
         });
     }
 
-    println!("Request chunks: {}", request_chunks.len());
+    info!("Request chunks: {}", request_chunks.len());
 
     let mut client = PackageServiceClient::connect("http://[::1]:15323").await?;
     let response = client.prepare(tokio_stream::iter(request_chunks)).await?;
     let res = response.into_inner();
 
-    println!("Source ID: {}", res.source_id);
+    info!("Source ID: {}", res.source_id);
 
     Ok((res.source_id, source_hash.to_string()))
 }
@@ -87,9 +88,10 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
     let work_dir = tempdir()?;
     let workdir_path = work_dir.path().canonicalize()?;
 
-    println!("Preparing working dir: {:?}", workdir_path);
+    info!("Preparing working dir: {:?}", workdir_path);
 
     if source.kind == PackageSourceKind::Unknown as i32 {
+        error!("Unknown source kind");
         return Err(anyhow::anyhow!("Unknown source kind"));
     }
 
@@ -122,11 +124,12 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
     }
 
     if source.kind == PackageSourceKind::Http as i32 {
-        println!("Downloading source: {:?}", &source.uri);
+        info!("Downloading source: {:?}", &source.uri);
 
         let url = Url::parse(&source.uri)?;
 
         if url.scheme() != "http" && url.scheme() != "https" {
+            error!("Invalid HTTP source URL");
             return Err(anyhow::anyhow!("Invalid HTTP source URL"));
         }
 
@@ -134,20 +137,20 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
         let response_bytes = response.as_ref();
 
         if let Some(source_kind) = infer::get(response_bytes) {
-            println!("Preparing source kind: {:?}", source_kind);
+            info!("Preparing source kind: {:?}", source_kind);
 
             match source_kind.mime_type() {
                 "application/gzip" => {
                     let temp_file = NamedTempFile::new()?;
                     write(&temp_file, response_bytes).await?;
                     store::unpack_source(&workdir_path, temp_file.path())?;
-                    println!("Prepared packed source: {:?}", workdir_path);
+                    info!("Prepared packed source: {:?}", workdir_path);
                 }
                 _ => {
                     let source_file_name = url.path_segments().unwrap().last();
                     let source_file = source_file_name.unwrap();
                     write(&source_file, response_bytes).await?;
-                    println!("Prepared source file: {:?}", source_file);
+                    info!("Prepared source file: {:?}", source_file);
                 }
             }
         }
@@ -156,13 +159,13 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
     if source.kind == PackageSourceKind::Local as i32 {
         let source_path = Path::new(&source.uri).canonicalize()?;
 
-        println!("Preparing source path: {:?}", source_path);
+        info!("Preparing source path: {:?}", source_path);
 
         if let Ok(Some(source_kind)) = infer::get_from_path(&source_path) {
-            println!("Preparing source kind: {:?}", source_kind);
+            info!("Preparing source kind: {:?}", source_kind);
 
             if source_kind.mime_type() == "application/gzip" {
-                println!("Preparing packed source: {:?}", work_dir);
+                info!("Preparing packed source: {:?}", work_dir);
                 store::unpack_source(&workdir_path, &source_path)?;
             }
         }
@@ -170,7 +173,7 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
         if source_path.is_file() {
             let dest = workdir_path.join(source_path.file_name().unwrap());
             copy(&source_path, &dest).await?;
-            println!(
+            info!(
                 "Preparing source file: {:?} -> {:?}",
                 source_path.display(),
                 dest.display()
@@ -193,7 +196,7 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
 
                 let dest = workdir_path.join(src.file_name().unwrap());
                 copy(src, &dest).await?;
-                println!(
+                info!(
                     "Preparing source file: {:?} -> {:?}",
                     src.display(),
                     dest.display()
@@ -210,7 +213,7 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
         return Err(anyhow::anyhow!("No source files found"));
     }
 
-    println!("Preparing source files: {:?}", workdir_files);
+    info!("Preparing source files: {:?}", workdir_files);
 
     let workdir_files_hashes = store::get_file_hashes(&workdir_files)?;
     let workdir_hash = store::get_source_hash(&workdir_files_hashes)?;
@@ -219,7 +222,7 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
         return Err(anyhow::anyhow!("Failed to get source hash"));
     }
 
-    println!("Source hash: {}", workdir_hash);
+    info!("Source hash: {}", workdir_hash);
 
     if let Some(request_hash) = &source.hash {
         if &workdir_hash != request_hash {
@@ -231,13 +234,13 @@ async fn prepare(name: &str, source: &PackageSource) -> Result<(i32, String), an
     let source_tar = NamedTempFile::new()?;
     let source_tar_path = source_tar.path().canonicalize()?;
 
-    println!("Creating source tar: {:?}", source_tar);
+    info!("Creating source tar: {:?}", source_tar);
 
     store::compress_files(&workdir_path, &source_tar_path, &workdir_files)?;
 
     set_permissions(&source_tar, Permissions::from_mode(0o444)).await?;
 
-    println!("Source tar: {}", source_tar_path.display());
+    info!("Source tar: {}", source_tar_path.display());
 
     prepare_source(name, &workdir_hash, &source_tar_path).await
 }
@@ -265,18 +268,18 @@ async fn build(
         let store_path_tar = store_path_dir.with_extension("tar.gz");
 
         if store_path_dir.exists() {
-            println!("Using existing source: {}", store_path_dir.display());
+            info!("Using existing source: {}", store_path_dir.display());
             return Ok(());
         }
 
         if store_path_tar.exists() {
-            println!("Using existing tar: {}", store_path_tar.display());
+            info!("Using existing tar: {}", store_path_tar.display());
 
             fs::create_dir_all(&store_path_dir).await?;
 
             store::unpack_source(&store_path_dir, &store_path_tar)?;
 
-            println!("Unpacked source: {}", store_path_dir.display());
+            info!("Unpacked source: {}", store_path_dir.display());
 
             return Ok(());
         }
@@ -291,18 +294,18 @@ async fn build(
                 fs::set_permissions(store_path_tar.clone(), permissions).await?;
 
                 let file_name = store_path_tar.file_name().unwrap();
-                println!("Stored tar: {}", file_name.to_string_lossy());
+                info!("Stored tar: {}", file_name.to_string_lossy());
             }
             Err(e) => eprintln!("Failed source file: {}", e),
         }
 
-        println!("Stored tar: {}", store_path_tar.display());
+        info!("Stored tar: {}", store_path_tar.display());
 
         fs::create_dir_all(&store_path_dir).await?;
 
         store::unpack_source(&store_path_dir, &store_path_tar)?;
 
-        println!("Unpacked source: {}", store_path_dir.display());
+        info!("Unpacked source: {}", store_path_dir.display());
     }
 
     Ok(())

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -11,6 +11,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use tar::Archive;
 use tar::Builder;
+use tracing::info;
 use uuid::Uuid;
 use walkdir::WalkDir;
 
@@ -130,7 +131,7 @@ pub fn compress_files(
     let tar_encoder = GzEncoder::new(tar.try_clone()?, Compression::default());
     let mut tar_builder = Builder::new(tar_encoder);
 
-    println!("Compressing: {}", source.display());
+    info!("Compressing: {}", source.display());
 
     for path in source_files {
         if path == source {
@@ -139,7 +140,7 @@ pub fn compress_files(
 
         let relative_path = path.strip_prefix(source)?;
 
-        println!("Adding: {}", relative_path.display());
+        info!("Adding: {}", relative_path.display());
 
         if path.is_file() {
             tar_builder.append_path_with_name(path.clone(), relative_path)?;


### PR DESCRIPTION
This introduces tracing to vorpal by utilizing `tracing` and `tracing_subscriber` crates. Furthermore, it introduces a new argument to the tool, which defaults to `Level::INFO` but can be set by `--level <LEVEL>`. 

## Changes
- introduce a new argument to the base command `level` to configure the logging level.
- the new `level` argument defaults to `Level::INFO` but can be set via `--level <LEVEL>`
- changes (almost) all `println!` calls to `info!` or `error!` logging calls **(should be revised)**