### PR TITLE
Fix PackageTarget.from_str for linux systems

### DIFF
--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -38,9 +38,7 @@ pub trait PackageTarget {
 
 impl PackageTarget for PackageSystem {
     fn from_str(system: &str) -> Self {
-        let target = system.to_lowercase().replace("_", "-");
-
-        match target.as_str() {
+        match system {
             "aarch64-linux" => Aarch64Linux,
             "aarch64-macos" => Aarch64Macos,
             "x86_64-linux" => X8664Linux,
@@ -52,4 +50,32 @@ impl PackageTarget for PackageSystem {
 
 pub fn get_package_system<T: PackageTarget>(system: &str) -> T {
     T::from_str(system)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_package_target_from_str() {
+        let pairs = vec![
+            ("aarch64-linux", Aarch64Linux),
+            ("aarch64-macos", Aarch64Macos),
+            ("x86_64-linux", X8664Linux),
+            ("x86_64-macos", X8664Macos),
+            ("unknown", PackageSystem::default()),
+            ("armv6l-linux", PackageSystem::default()),
+            ("armv7l-linux", PackageSystem::default()),
+            ("i686-linux", PackageSystem::default()),
+            ("mipsel-linux", PackageSystem::default()),
+            ("armv5tel-linux", PackageSystem::default()),
+            ("powerpc64le-linux", PackageSystem::default()),
+            ("riscv64-linux", PackageSystem::default()),
+            ("x86_64-freebsd", PackageSystem::default()),
+        ];
+
+        for (arch, expected) in pairs {
+            assert_eq!(PackageSystem::from_str(arch), expected);
+        }
+    }
 }


### PR DESCRIPTION
Starting the worker on linux systems (NixOS) makes the worker start with `unknown` target, which breaks the vorpal builds as well.

On linux, the `get_default_system` function [here](https://github.com/ALT-F4-LLC/vorpal/blob/abe9451d3517a09dec47f1d7fee18b5d08345fc4/cli/src/main.rs#L74) returns `ARCH: x86_64, OS: linux -> 'x86_64-linux'`, which is then passed to the `get_package_system` function [here](https://github.com/ALT-F4-LLC/vorpal/blob/abe9451d3517a09dec47f1d7fee18b5d08345fc4/cli/src/main.rs#L88). 

The `get_package_system` function contains `let target = system.to_lowercase().replace("_", "-");` line [here](https://github.com/ALT-F4-LLC/vorpal/blob/abe9451d3517a09dec47f1d7fee18b5d08345fc4/schema/src/lib.rs#L41), which converts `x86_64-linux` to `x86-64-linux`, which doesn't match any of the `PackageTarget`s.

This PR removes the `let target = system.to_lowercase().replace("_", "-");` line since it is not needed, fixing the issue. Also adds tests for the `PackageTarget.from_str` function on the `scheme/src/lib.rs`  file.

P.S.: Sorry for the late PR :sweat_smile: 