### PR TITLE
Split registry implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,6 +3216,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -556,11 +556,16 @@ async fn main() -> Result<()> {
                 }
 
                 let backend: Box<dyn RegistryBackend> = match backend {
-                    RegistryServerBackend::Local => Box::new(vorpal_registry::LocalRegistryBackend),
-                    RegistryServerBackend::S3 => Box::new(vorpal_registry::S3RegistryBackend {
-                        bucket: registry_backend_s3_bucket.clone(),
-                    }),
-                    RegistryServerBackend::GHA => Box::new(vorpal_registry::GhaRegistryBackend),
+                    RegistryServerBackend::Local => {
+                        Box::new(vorpal_registry::LocalRegistryBackend::new()?)
+                    }
+                    RegistryServerBackend::S3 => Box::new(
+                        vorpal_registry::S3RegistryBackend::new(registry_backend_s3_bucket.clone())
+                            .await?,
+                    ),
+                    RegistryServerBackend::GHA => {
+                        Box::new(vorpal_registry::GhaRegistryBackend::new()?)
+                    }
                     RegistryServerBackend::Unknown => unreachable!(),
                 };
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,7 +18,7 @@ use tonic::transport::{Channel, Server};
 use tracing::{info, warn, Level};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::FmtSubscriber;
-use vorpal_registry::{RegistryServer, RegistryServerBackend};
+use vorpal_registry::{RegistryBackend, RegistryServer, RegistryServerBackend};
 use vorpal_schema::{
     get_artifact_system,
     vorpal::{
@@ -555,10 +555,16 @@ async fn main() -> Result<()> {
                     bail!("s3 backend requires '--registry-backend-s3-bucket' parameter");
                 }
 
-                let service = RegistryServiceServer::new(RegistryServer::new(
-                    backend,
-                    registry_backend_s3_bucket.clone(),
-                ));
+                let backend: Box<dyn RegistryBackend> = match backend {
+                    RegistryServerBackend::Local => Box::new(vorpal_registry::LocalRegistryBackend),
+                    RegistryServerBackend::S3 => Box::new(vorpal_registry::S3RegistryBackend {
+                        bucket: registry_backend_s3_bucket.clone(),
+                    }),
+                    RegistryServerBackend::GHA => Box::new(vorpal_registry::GhaRegistryBackend),
+                    RegistryServerBackend::Unknown => unreachable!(),
+                };
+
+                let service = RegistryServiceServer::new(RegistryServer::new(backend));
 
                 info!("registry service: [::]:{}", port);
 

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -12,6 +12,7 @@ rsa = { default-features = false, version = "0" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 sha2 = { default-features = false, version = "0" }
+thiserror = { default-features = false, version = "2" }
 tokio = { default-features = false, features = ["process", "rt-multi-thread"], version = "1" }
 tokio-stream = { default-features = false, features = ["io-util"], version = "0" }
 tonic = { default-features = false, version = "0" }

--- a/registry/src/gha.rs
+++ b/registry/src/gha.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
 use reqwest::{
@@ -205,9 +205,8 @@ pub struct GhaRegistryBackend {
 
 impl GhaRegistryBackend {
     pub fn new() -> Result<Self, RegistryError> {
-        let cache_client = CacheClient::new().map_err(|err| {
-            RegistryError::FailedToCreateGhaClient(err.to_string())
-        })?;
+        let cache_client = CacheClient::new()
+            .map_err(|err| RegistryError::FailedToCreateGhaClient(err.to_string()))?;
 
         Ok(Self { cache_client })
     }
@@ -227,7 +226,8 @@ impl RegistryBackend for GhaRegistryBackend {
 
         info!("get cache entry -> {}", cache_key);
 
-        let cache_entry = &self.cache_client
+        let cache_entry = &self
+            .cache_client
             .get_cache_entry(&cache_key, &request.hash)
             .await
             .map_err(|e| {
@@ -271,7 +271,8 @@ impl RegistryBackend for GhaRegistryBackend {
             return Ok(());
         }
 
-        let cache_entry = &self.cache_client
+        let cache_entry = &self
+            .cache_client
             .get_cache_entry(&cache_key, &request.hash)
             .await
             .expect("failed to get cache entry");
@@ -319,7 +320,8 @@ impl RegistryBackend for GhaRegistryBackend {
 
         let cache_size = data.len() as u64;
 
-        let cache_reserve = &self.cache_client
+        let cache_reserve = &self
+            .cache_client
             .reserve_cache(cache_key, hash.clone(), Some(cache_size))
             .await
             .map_err(|e| {

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -23,6 +23,15 @@ pub use local::LocalRegistryBackend;
 pub use s3::S3RegistryBackend;
 pub use gha::GhaRegistryBackend;
 
+#[derive(thiserror::Error, Debug)]
+pub enum RegistryError {
+    #[error("missing s3 bucket")]
+    MissingS3Bucket,
+
+    #[error("failed to create GHA cache client: {0}")]
+    FailedToCreateGhaClient(String),
+}
+
 const DEFAULT_GRPC_CHUNK_SIZE: usize = 2 * 1024 * 1024; // 2MB
 
 pub struct PushMetadata {

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -16,12 +16,12 @@ use vorpal_schema::vorpal::registry::v0::{
 };
 use vorpal_store::paths::get_public_key_path;
 
+pub mod gha;
 pub mod local;
 pub mod s3;
-pub mod gha;
+pub use gha::GhaRegistryBackend;
 pub use local::LocalRegistryBackend;
 pub use s3::S3RegistryBackend;
-pub use gha::GhaRegistryBackend;
 
 #[derive(thiserror::Error, Debug)]
 pub enum RegistryError {

--- a/registry/src/local.rs
+++ b/registry/src/local.rs
@@ -17,7 +17,11 @@ impl LocalRegistryBackend {
     }
 }
 
-fn get_registry_path(kind: RegistryKind, hash: &str, name: &str) -> Result<std::path::PathBuf, Status> {
+fn get_registry_path(
+    kind: RegistryKind,
+    hash: &str,
+    name: &str,
+) -> Result<std::path::PathBuf, Status> {
     match kind {
         RegistryKind::Artifact => Ok(get_artifact_archive_path(hash, name)),
         RegistryKind::ArtifactSource => Ok(get_source_archive_path(hash, name)),

--- a/registry/src/local.rs
+++ b/registry/src/local.rs
@@ -1,0 +1,96 @@
+use tokio::{
+    fs::{read, write},
+    sync::mpsc,
+};
+use tonic::{async_trait, Status};
+use vorpal_schema::vorpal::registry::v0::{RegistryKind, RegistryPullResponse, RegistryRequest};
+use vorpal_store::paths::{get_artifact_archive_path, get_source_archive_path, set_timestamps};
+
+use crate::{PushMetadata, RegistryBackend, DEFAULT_GRPC_CHUNK_SIZE};
+
+#[derive(Clone, Debug)]
+pub struct LocalRegistryBackend;
+
+#[async_trait]
+impl RegistryBackend for LocalRegistryBackend {
+    async fn exists(&self, request: &RegistryRequest) -> Result<(), Status> {
+        let path = match request.kind() {
+            RegistryKind::Artifact => {
+                vorpal_store::paths::get_artifact_archive_path(&request.hash, &request.name)
+            }
+            RegistryKind::ArtifactSource => {
+                vorpal_store::paths::get_source_archive_path(&request.hash, &request.name)
+            }
+            _ => return Err(Status::invalid_argument("unsupported store kind")),
+        };
+
+        if !path.exists() {
+            return Err(Status::not_found("store path not found"));
+        }
+
+        Ok(())
+    }
+
+    async fn pull(
+        &self,
+        request: &RegistryRequest,
+        tx: mpsc::Sender<Result<RegistryPullResponse, Status>>,
+    ) -> Result<(), Status> {
+        let path = match request.kind() {
+            RegistryKind::Artifact => get_artifact_archive_path(&request.hash, &request.name),
+            RegistryKind::ArtifactSource => get_source_archive_path(&request.hash, &request.name),
+            _ => return Err(Status::invalid_argument("unsupported store kind")),
+        };
+
+        if !path.exists() {
+            return Err(Status::not_found("store path not found"));
+        }
+
+        let data = read(&path)
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        for chunk in data.chunks(DEFAULT_GRPC_CHUNK_SIZE) {
+            tx.send(Ok(RegistryPullResponse {
+                data: chunk.to_vec(),
+            }))
+            .await
+            .map_err(|err| Status::internal(format!("failed to send store chunk: {:?}", err)))?;
+        }
+
+        Ok(())
+    }
+
+    async fn push(&self, metadata: PushMetadata) -> Result<(), Status> {
+        let PushMetadata {
+            data_kind,
+            hash,
+            name,
+            data,
+        } = metadata;
+
+        let path = match data_kind {
+            RegistryKind::Artifact => get_artifact_archive_path(&hash, &name),
+            RegistryKind::ArtifactSource => get_source_archive_path(&hash, &name),
+            _ => return Err(Status::invalid_argument("unsupported store kind")),
+        };
+
+        if path.exists() {
+            return Ok(());
+        }
+
+        write(&path, &data)
+            .await
+            .map_err(|err| Status::internal(format!("failed to write store path: {:?}", err)))?;
+
+        set_timestamps(&path)
+            .await
+            .map_err(|err| Status::internal(format!("failed to sanitize path: {:?}", err)))?;
+
+        Ok(())
+    }
+
+    fn box_clone(&self) -> Box<dyn RegistryBackend> {
+        Box::new(self.clone())
+    }
+}

--- a/registry/src/s3.rs
+++ b/registry/src/s3.rs
@@ -135,4 +135,3 @@ impl RegistryBackend for S3RegistryBackend {
         Box::new(self.clone())
     }
 }
-

--- a/registry/src/s3.rs
+++ b/registry/src/s3.rs
@@ -1,0 +1,159 @@
+use aws_sdk_s3::Client;
+use tokio::sync::mpsc;
+use tonic::{async_trait, Status};
+use vorpal_schema::vorpal::registry::v0::{RegistryKind, RegistryPullResponse, RegistryRequest};
+use vorpal_store::paths::{self, get_store_dir_name};
+
+use crate::{PushMetadata, RegistryBackend};
+
+#[derive(Clone, Debug)]
+pub struct S3RegistryBackend {
+    pub bucket: Option<String>,
+}
+
+#[async_trait]
+impl RegistryBackend for S3RegistryBackend {
+    async fn exists(&self, request: &RegistryRequest) -> Result<(), Status> {
+        let Some(bucket) = &self.bucket else {
+            return Err(Status::invalid_argument("missing s3 bucket"));
+        };
+
+        let artifact_key = match request.kind() {
+            RegistryKind::Artifact => format!(
+                "store/{}.artifact",
+                paths::get_store_dir_name(&request.hash, &request.name)
+            ),
+            RegistryKind::ArtifactSource => format!(
+                "store/{}.source",
+                paths::get_store_dir_name(&request.hash, &request.name)
+            ),
+            _ => return Err(Status::invalid_argument("unsupported store kind")),
+        };
+
+        let client_config = aws_config::load_from_env().await;
+        let client = Client::new(&client_config);
+
+        let head_result = client
+            .head_object()
+            .bucket(bucket)
+            .key(&artifact_key)
+            .send()
+            .await;
+
+        if head_result.is_err() {
+            return Err(Status::not_found("store path not found"));
+        }
+
+        Ok(())
+    }
+
+    async fn pull(
+        &self,
+        request: &RegistryRequest,
+        tx: mpsc::Sender<Result<RegistryPullResponse,Status> > ,
+    ) -> Result<(), Status> {
+        let Some(bucket) = &self.bucket else {
+            return Err(Status::invalid_argument("missing s3 bucket"));
+        };
+
+        let client_bucket_name = bucket;
+
+        let artifact_key = match request.kind() {
+            RegistryKind::Artifact => format!(
+                "store/{}.artifact",
+                get_store_dir_name(&request.hash, &request.name)
+            ),
+            RegistryKind::ArtifactSource => {
+                format!(
+                    "store/{}.source",
+                    get_store_dir_name(&request.hash, &request.name)
+                )
+            }
+            _ => return Err(Status::invalid_argument("unsupported store kind")),
+        };
+
+        let client_config = aws_config::load_from_env().await;
+        let client = Client::new(&client_config);
+
+        client
+            .head_object()
+            .bucket(client_bucket_name.clone())
+            .key(artifact_key.clone())
+            .send()
+            .await
+            .map_err(|err| Status::not_found(err.to_string()))?;
+
+        let mut stream = client
+            .get_object()
+            .bucket(client_bucket_name)
+            .key(artifact_key)
+            .send()
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?
+            .body;
+
+        while let Some(chunk_result) = stream.next().await {
+            let chunk = chunk_result.map_err(|err| Status::internal(err.to_string()))?;
+
+            tx.send(Ok(RegistryPullResponse {
+                data: chunk.to_vec(),
+            }))
+            .await
+            .map_err(|err| Status::internal(format!("failed to send store chunk: {:?}", err)))?;
+        }
+
+        Ok(())
+    }
+
+    async fn push(&self, metadata: PushMetadata) -> Result<(), Status> {
+        let PushMetadata {
+            data_kind,
+            hash,
+            name,
+            data,
+        } = metadata;
+
+        let Some(bucket) = &self.bucket else {
+            return Err(Status::invalid_argument("missing s3 bucket"));
+        };
+
+        let artifact_key = match data_kind {
+            RegistryKind::Artifact => {
+                format!("store/{}.artifact", get_store_dir_name(&hash, &name))
+            }
+            RegistryKind::ArtifactSource => {
+                format!("store/{}.source", get_store_dir_name(&hash, &name))
+            }
+            _ => return Err(Status::invalid_argument("unsupported store kind")),
+        };
+
+        let client_config = aws_config::load_from_env().await;
+        let client = Client::new(&client_config);
+
+        let head_result = client
+            .head_object()
+            .bucket(bucket)
+            .key(&artifact_key)
+            .send()
+            .await;
+
+        if head_result.is_ok() {
+            return Ok(());
+        }
+
+        let _ = client
+            .put_object()
+            .bucket(bucket)
+            .key(artifact_key)
+            .body(data.into())
+            .send()
+            .await
+            .map_err(|err| Status::internal(format!("failed to write store path: {:?}", err)))?;
+
+        Ok(())
+    }
+
+    fn box_clone(&self) -> Box<dyn RegistryBackend> {
+        Box::new(self.clone())
+    }
+}


### PR DESCRIPTION
This PR introduces a new `RegistryBackend` trait and splits the current registry implementations into two separate implementations `LocalRegistryBackend` and `S3RegistryBackend`.

I’m not too happy to include the box_clone in the trait (we probably don't need to clone), but it's probably fine for now.