### PR TITLE
Added export flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,7 @@ dependencies = [
  "console",
  "petgraph",
  "port-selector",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ clap = { default-features = false, features = ["color", "derive", "error-context
 console = { version = "0" }
 petgraph = { default-features = false, features = ["graphmap"], version = "0" }
 port-selector = { default-features = false, version = "0" }
+serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, version = "1" }
 tokio-stream = { default-features = false, version = "0" }
 tonic = { default-features = false, version = "0" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use std::{
         consts::{ARCH, OS},
         var,
     },
-    path::Path,
+    path::{Path, PathBuf},
     process::Stdio,
 };
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -35,7 +35,6 @@ use vorpal_sdk::config::{
     ConfigContext,
 };
 use vorpal_store::paths::{get_artifact_path, get_public_key_path};
-
 use vorpal_worker::artifact::ArtifactServer;
 
 mod artifact;
@@ -58,6 +57,9 @@ pub struct VorpalToml {
 #[derive(Subcommand)]
 enum Command {
     Artifact {
+        #[arg(default_value_t = false, long)]
+        export: bool,
+
         #[arg(long)]
         name: String,
 
@@ -180,6 +182,157 @@ async fn start_config(
     Ok((process, service))
 }
 
+async fn get_config_file_path(
+    artifact_system: ArtifactSystem,
+    language: String,
+    registry: String,
+    rust_bin: Option<String>,
+    rust_path: Option<String>,
+    service: String,
+) -> Result<PathBuf> {
+    match language.as_str() {
+        "rust" => {
+            if rust_bin.is_none() {
+                bail!("no `--rust-bin` specified");
+            }
+
+            if rust_path.is_none() {
+                bail!("no `--rust-path` specified");
+            }
+
+            // Setup context
+
+            let mut build_context = ConfigContext::new(0, registry.clone(), artifact_system);
+
+            // Setup toolchain artifacts
+
+            let protoc = protoc::artifact(&mut build_context).await?;
+            let toolchain = rust::toolchain_artifact(&mut build_context, "vorpal").await?;
+
+            // Setup build
+
+            let build_order = build::get_order(&build_context.artifact_id).await?;
+
+            let mut ready_artifacts = vec![];
+
+            for artifact_id in &build_order {
+                match build_context.artifact_id.get(artifact_id) {
+                    None => bail!("build artifact not found: {}", artifact_id.name),
+                    Some(artifact) => {
+                        for artifact in &artifact.artifacts {
+                            if !ready_artifacts.contains(&artifact) {
+                                bail!("Artifact not found: {}", artifact.name);
+                            }
+                        }
+
+                        build(artifact, artifact_id, artifact_system, &registry, &service).await?;
+
+                        ready_artifacts.push(artifact_id);
+                    }
+                }
+            }
+
+            // Get protoc
+
+            let protoc_path = Path::new(&format!(
+                "{}/bin/protoc",
+                get_artifact_path(&protoc.hash, &protoc.name).display()
+            ))
+            .to_path_buf();
+
+            if !protoc_path.exists() {
+                bail!("protoc not found: {}", protoc_path.display());
+            }
+
+            // Get toolchain
+
+            let toolchain_path = get_artifact_path(&toolchain.hash, &toolchain.name);
+
+            if !toolchain_path.exists() {
+                bail!("config toolchain not found: {}", toolchain_path.display());
+            }
+
+            let toolchain_target = rust::get_toolchain_target(artifact_system)?;
+            let toolchain_version = get_rust_toolchain_version();
+
+            let toolchain_bin_path = Path::new(&format!(
+                "{}/toolchains/{}-{}/bin",
+                toolchain_path.display(),
+                toolchain_version,
+                toolchain_target
+            ))
+            .to_path_buf();
+
+            let toolchain_cargo_path =
+                Path::new(&format!("{}/cargo", toolchain_bin_path.display())).to_path_buf();
+
+            if !toolchain_cargo_path.exists() {
+                bail!("cargo not found: {}", toolchain_cargo_path.display());
+            }
+
+            // Build configuration with toolchain
+
+            let mut command = process::Command::new(toolchain_cargo_path);
+
+            // Setup environment variables
+
+            command.env(
+                "PATH",
+                format!(
+                    "{}:{}/bin:{}",
+                    toolchain_bin_path.display(),
+                    get_artifact_path(&protoc.hash, &protoc.name).display(),
+                    var("PATH").unwrap_or_default()
+                )
+                .as_str(),
+            );
+
+            command.env("RUSTUP_HOME", toolchain_path.display().to_string());
+
+            command.env(
+                "RUSTUP_TOOLCHAIN",
+                format!("{}-{}", toolchain_version, toolchain_target),
+            );
+
+            // Setup command
+
+            let config_bin = rust_bin.as_ref().unwrap();
+
+            command.args(["build", "--bin", config_bin]);
+
+            let mut process = command
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|_| anyhow!("failed to start config server"))?;
+
+            let stdout = process.stdout.take().unwrap();
+            let stderr = process.stderr.take().unwrap();
+
+            let stdout = LinesStream::new(BufReader::new(stdout).lines());
+            let stderr = LinesStream::new(BufReader::new(stderr).lines());
+
+            let mut stdio_merged = StreamExt::merge(stdout, stderr);
+
+            while let Some(line) = stdio_merged.next().await {
+                let line = line.map_err(|err| anyhow!("failed to read line: {:?}", err))?;
+
+                info!("{}", line);
+            }
+
+            let config_file_path = format!(
+                "{}/target/debug/{}",
+                rust_path.as_ref().unwrap(),
+                config_bin
+            );
+
+            Ok(Path::new(&config_file_path).to_path_buf())
+        }
+
+        _ => bail!("unsupported language: {}", language),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -196,6 +349,7 @@ async fn main() -> Result<()> {
 
     match &command {
         Command::Artifact {
+            export: export_artifact,
             name,
             service,
             system,
@@ -217,166 +371,28 @@ async fn main() -> Result<()> {
             tracing::subscriber::set_global_default(subscriber)
                 .expect("setting default subscriber");
 
-            // Load the system
-
-            let artifact_system: ArtifactSystem = get_artifact_system(system);
-
-            if artifact_system == UnknownSystem {
-                bail!("unknown target: {}", artifact_system.as_str_name());
+            if service.is_empty() {
+                bail!("no `--artifact-service` specified");
             }
 
-            // Build the configuration
+            let system: ArtifactSystem = get_artifact_system(system);
 
-            let config_file = match language.as_str() {
-                "rust" => {
-                    if rust_bin.is_none() {
-                        bail!("no `--rust-bin` specified");
-                    }
+            if system == UnknownSystem {
+                bail!("unknown target: {}", system.as_str_name());
+            }
 
-                    if rust_path.is_none() {
-                        bail!("no `--rust-path` specified");
-                    }
-
-                    // Setup context
-
-                    let mut build_context =
-                        ConfigContext::new(0, registry.clone(), artifact_system);
-
-                    // Setup toolchain artifacts
-
-                    let protoc = protoc::artifact(&mut build_context).await?;
-                    let toolchain = rust::toolchain_artifact(&mut build_context, "vorpal").await?;
-
-                    // Setup build
-
-                    let build_order = build::get_order(&build_context.artifact_id).await?;
-
-                    let mut ready_artifacts = vec![];
-
-                    for artifact_id in &build_order {
-                        match build_context.artifact_id.get(artifact_id) {
-                            None => bail!("build artifact not found: {}", artifact_id.name),
-                            Some(artifact) => {
-                                for artifact in &artifact.artifacts {
-                                    if !ready_artifacts.contains(&artifact) {
-                                        bail!("Artifact not found: {}", artifact.name);
-                                    }
-                                }
-
-                                build(artifact, artifact_id, artifact_system, &registry, service)
-                                    .await?;
-
-                                ready_artifacts.push(artifact_id);
-                            }
-                        }
-                    }
-
-                    // Get protoc
-
-                    let protoc_path = Path::new(&format!(
-                        "{}/bin/protoc",
-                        get_artifact_path(&protoc.hash, &protoc.name).display()
-                    ))
-                    .to_path_buf();
-
-                    if !protoc_path.exists() {
-                        bail!("protoc not found: {}", protoc_path.display());
-                    }
-
-                    // Get toolchain
-
-                    let toolchain_path = get_artifact_path(&toolchain.hash, &toolchain.name);
-
-                    if !toolchain_path.exists() {
-                        bail!("config toolchain not found: {}", toolchain_path.display());
-                    }
-
-                    let toolchain_target = rust::get_toolchain_target(artifact_system)?;
-                    let toolchain_version = get_rust_toolchain_version();
-
-                    let toolchain_bin_path = Path::new(&format!(
-                        "{}/toolchains/{}-{}/bin",
-                        toolchain_path.display(),
-                        toolchain_version,
-                        toolchain_target
-                    ))
-                    .to_path_buf();
-
-                    let toolchain_cargo_path =
-                        Path::new(&format!("{}/cargo", toolchain_bin_path.display())).to_path_buf();
-
-                    if !toolchain_cargo_path.exists() {
-                        bail!("cargo not found: {}", toolchain_cargo_path.display());
-                    }
-
-                    // Build configuration with toolchain
-
-                    let mut command = process::Command::new(toolchain_cargo_path);
-
-                    // Setup environment variables
-
-                    command.env(
-                        "PATH",
-                        format!(
-                            "{}:{}/bin:{}",
-                            toolchain_bin_path.display(),
-                            get_artifact_path(&protoc.hash, &protoc.name).display(),
-                            var("PATH").unwrap_or_default()
-                        )
-                        .as_str(),
-                    );
-
-                    command.env("RUSTUP_HOME", toolchain_path.display().to_string());
-
-                    command.env(
-                        "RUSTUP_TOOLCHAIN",
-                        format!("{}-{}", toolchain_version, toolchain_target),
-                    );
-
-                    // Setup command
-
-                    let config_bin = rust_bin.as_ref().unwrap();
-
-                    command.args(["build", "--bin", config_bin]);
-
-                    let mut process = command
-                        .stdout(Stdio::piped())
-                        .stderr(Stdio::piped())
-                        .spawn()
-                        .map_err(|_| anyhow!("failed to start config server"))?;
-
-                    let stdout = process.stdout.take().unwrap();
-                    let stderr = process.stderr.take().unwrap();
-
-                    let stdout = LinesStream::new(BufReader::new(stdout).lines());
-                    let stderr = LinesStream::new(BufReader::new(stderr).lines());
-
-                    let mut stdio_merged = StreamExt::merge(stdout, stderr);
-
-                    while let Some(line) = stdio_merged.next().await {
-                        let line = line.map_err(|err| anyhow!("failed to read line: {:?}", err))?;
-
-                        info!("{}", line);
-                    }
-
-                    let config_file_path = format!(
-                        "{}/target/debug/{}",
-                        rust_path.as_ref().unwrap(),
-                        config_bin
-                    );
-
-                    Path::new(&config_file_path).to_path_buf()
-                }
-
-                _ => bail!("unsupported language: {}", language),
-            };
+            let config_file = get_config_file_path(
+                system,
+                language,
+                registry.clone(),
+                rust_bin.clone(),
+                rust_path.clone(),
+                service.clone(),
+            )
+            .await?;
 
             if !config_file.exists() {
                 bail!("config file not found: {}", config_file.display());
-            }
-
-            if service.is_empty() {
-                bail!("no `--artifact-service` specified");
             }
 
             let (mut config_process, mut config_service) =
@@ -389,43 +405,58 @@ async fn main() -> Result<()> {
                 }
             };
 
-            let config = config_response.into_inner();
+            let config_response = config_response.into_inner();
 
-            let config_artifact_id = config
+            let artifact_id_selected = config_response
+                .clone()
                 .artifacts
                 .into_iter()
                 .find(|a| a.name == *name)
                 .ok_or_else(|| anyhow!("artifact not found: {}", name))?;
 
-            // Create the artifact graph and map
-
-            let mut build_artifact = HashMap::<ArtifactId, Artifact>::new();
-
             // Get the artifact
 
-            let config_artifact_request = tonic::Request::new(config_artifact_id.clone());
+            let artifact_request = tonic::Request::new(artifact_id_selected.clone());
 
-            let config_artifact_response =
-                match config_service.get_artifact(config_artifact_request).await {
-                    Ok(res) => res,
-                    Err(error) => {
-                        bail!("failed to evaluate artifact: {}", error);
-                    }
-                };
+            let artifact_response = match config_service.get_artifact(artifact_request).await {
+                Ok(res) => res,
+                Err(error) => {
+                    bail!("failed to evaluate artifact: {}", error);
+                }
+            };
 
-            let config_artifact = config_artifact_response.into_inner();
+            let artifact_selected = artifact_response.into_inner();
 
-            build_artifact.insert(config_artifact_id.clone(), config_artifact.clone());
+            let mut artifact = HashMap::<ArtifactId, Artifact>::new();
 
-            build::get_artifacts(&config_artifact, &mut build_artifact, &mut config_service)
-                .await?;
+            artifact.insert(artifact_id_selected.clone(), artifact_selected.clone());
 
-            let build_order = build::get_order(&build_artifact).await?;
+            build::get_artifacts(&artifact_selected, &mut artifact, &mut config_service).await?;
+
+            if *export_artifact {
+                let mut artifacts = vec![];
+
+                for a in artifact.values() {
+                    artifacts.push(a.clone());
+                }
+
+                artifacts.sort_by(|a, b| a.name.cmp(&b.name));
+
+                let export_json = serde_json::to_string_pretty(&artifacts).unwrap();
+
+                println!("{}", export_json);
+
+                return Ok(());
+            }
+
+            // Create the artifact graph and map
+
+            let build_order = build::get_order(&artifact).await?;
 
             let mut ready_artifacts = vec![];
 
             for artifact_id in &build_order {
-                match build_artifact.get(artifact_id) {
+                match artifact.get(artifact_id) {
                     None => bail!("Build artifact not found: {}", artifact_id.name),
                     Some(artifact) => {
                         for artifact in &artifact.artifacts {
@@ -434,7 +465,7 @@ async fn main() -> Result<()> {
                             }
                         }
 
-                        build(artifact, artifact_id, artifact_system, &registry, service).await?;
+                        build(artifact, artifact_id, system, &registry, service).await?;
 
                         ready_artifacts.push(artifact_id);
 

--- a/makefile
+++ b/makefile
@@ -49,16 +49,19 @@ dist: build
 # Development (with Vorpal)
 
 vorpal-config:
-	cargo build --bin 'vorpal-config'
+	cargo build --bin "vorpal-config"
+
+vorpal-export: vorpal-config
+	cargo run --bin "vorpal" -- artifact --export --name "vorpal" > "vorpal-$(ARCH)-$(OS).json"
 
 vorpal-shell: vorpal-config
-	cargo run --bin 'vorpal' -- artifact --name 'vorpal-shell'
+	cargo run --bin "vorpal" -- artifact --name "vorpal-shell"
 
 vorpal: vorpal-config
-	cargo run --bin 'vorpal' -- artifact --name 'vorpal'
+	cargo run --bin "vorpal" -- artifact --name "vorpal"
 
 vorpal-start:
-	cargo run --bin 'vorpal' -- start
+	cargo run --bin "vorpal" -- start
 
 # Vagrant environment
 


### PR DESCRIPTION
## Overview

This flag can be used to export an artifact configuration and all dependency artifact configurations.

## Example

```
vorpal artifact --export --name "vorpal"
```
