### PR TITLE
Adding release job to CI

### DIFF
--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -35,11 +35,7 @@ jobs:
       - run: ./script/dev.sh make dist
 
       - run: |
-          ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
-          if [ "$ARCH" = "arm64" ]; then
-            ARCH="aarch64"
-          fi
-          echo "ARCH=$ARCH" >> $GITHUB_ENV
+          echo "ARCH=$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/arm64/aarch64/')" >> $GITHUB_ENV
           echo "OS=$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - run: ls -alh dist
@@ -83,11 +79,7 @@ jobs:
       - run: ./script/install.sh
 
       - run: |
-          ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
-          if [ "$ARCH" = "arm64" ]; then
-            ARCH="aarch64"
-          fi
-          echo "ARCH=$ARCH" >> $GITHUB_ENV
+          echo "ARCH=$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/arm64/aarch64/')" >> $GITHUB_ENV
           echo "OS=$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  # schedule:
+  #   - cron: "0 8 * * *"
 
 jobs:
   code-quality:
@@ -108,56 +110,56 @@ jobs:
           cat worker_output.log || true
           kill $WORKER_PID || true
 
-  # release:
-  #   needs:
-  #     - test
-  #   permissions:
-  #     attestations: write
-  #     contents: write
-  #     id-token: write
-  #     packages: write
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         fail-on-cache-miss: true
-  #         pattern: vorpal-*
-  #
-  #     - run: git fetch --tags
-  #
-  #     - if: github.ref == 'refs/heads/main'
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       run: |
-  #         if gh release view edge > /dev/null 2>&1; then
-  #           gh release delete --cleanup-tag --yes edge
-  #         fi
-  #         git tag edge
-  #         git push --tags
-  #
-  #     - if: github.ref == 'refs/heads/main'
-  #       uses: softprops/action-gh-release@v2
-  #       with:
-  #         body: Latest artifacts from `main` branch when merged.
-  #         fail_on_unmatched_files: true
-  #         files: |
-  #           vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz
-  #           vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz
-  #         name: edge
-  #         prerelease: true
-  #         tag_name: refs/tags/edge
-  #
-  #     - run: |
-  #         mkdir -p dist/aarch64-linux
-  #         mkdir -p dist/x86_64-linux
-  #         tar -xzf vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
-  #         tar -xzf vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
-  #
-  #     - if: github.ref == 'refs/heads/main'
-  #       uses: actions/attest-build-provenance@v1
-  #       with:
-  #         subject-path: |
-  #           dist/aarch64-linux/vorpal
-  #           dist/x86_64-linux/vorpal
+  release:
+    # if: github.event.schedule != ''
+    needs:
+      - test
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: git fetch --tags
+
+      - uses: actions/download-artifact@v4
+        with:
+          fail-on-cache-miss: true
+          pattern: vorpal-dist-*
+
+      - run: ls -alh
+
+      # - env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     if gh release view nightly > /dev/null 2>&1; then
+      #       gh release delete --cleanup-tag --yes nightly
+      #     fi
+      #     git tag nightly
+      #     git push --tags
+
+      # - uses: softprops/action-gh-release@v2
+      #   with:
+      #     body: Nightly builds from `main` branch.
+      #     fail_on_unmatched_files: true
+      #     files: |
+      #       vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz
+      #       vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz
+      #     name: nightly
+      #     prerelease: true
+      #     tag_name: refs/tags/nightly
+
+      # - run: |
+      #     mkdir -p dist/aarch64-linux
+      #     mkdir -p dist/x86_64-linux
+      #     tar -xzf vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
+      #     tar -xzf vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
+
+      # - uses: actions/attest-build-provenance@v1
+      #   with:
+      #     subject-path: |
+      #       dist/aarch64-linux/vorpal
+      #       dist/x86_64-linux/vorpal

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -50,10 +50,10 @@ jobs:
     strategy:
       matrix:
         runner:
-          - macos-13
+          # - macos-13
           - macos-latest
           - ubuntu-latest
-          - ubuntu-latest-arm64
+          # - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - main
-  # schedule:
-  #   - cron: "0 8 * * *"
+  schedule:
+    - cron: "0 8 * * *"
 
 jobs:
   code-quality:
@@ -115,7 +115,7 @@ jobs:
           kill $WORKER_PID || true
 
   release:
-    # if: github.event.schedule != ''
+    if: github.event.schedule != ''
     needs:
       - test
     permissions:
@@ -157,23 +157,19 @@ jobs:
           tag_name: refs/tags/nightly
 
       - run: |
-          mkdir -p dist/aarch64-darwin
-          mkdir -p dist/aarch64-linux
-          mkdir -p dist/x86_64-darwin
-          mkdir -p dist/x86_64-linux
-          tar -xzf vorpal-dist-aarch64-darwin/vorpal-aarch64-darwin.tar.gz -C dist/aarch64-darwin
-          tar -xzf vorpal-dist-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
-          tar -xzf vorpal-dist-x86_64-darwin/vorpal-x86_64-darwin.tar.gz -C dist/x86_64-darwin
-          tar -xzf vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
-          ls -alh dist/aarch64-darwin 
-          ls -alh dist/aarch64-linux 
-          ls -alh dist/x86_64-darwin 
-          ls -alh dist/x86_64-linux 
+          mkdir -pv dist/aarch64-darwin
+          mkdir -pv dist/aarch64-linux
+          mkdir -pv dist/x86_64-darwin
+          mkdir -pv dist/x86_64-linux
+          tar -xzvf vorpal-dist-aarch64-darwin/vorpal-aarch64-darwin.tar.gz -C dist/aarch64-darwin
+          tar -xzvf vorpal-dist-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
+          tar -xzvf vorpal-dist-x86_64-darwin/vorpal-x86_64-darwin.tar.gz -C dist/x86_64-darwin
+          tar -xzvf vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
 
-      # - uses: actions/attest-build-provenance@v1
-      #   with:
-      #     subject-path: |
-      #       dist/aarch64-darwin/vorpal
-      #       dist/aarch64-linux/vorpal
-      #       dist/x86_64-darwin/vorpal
-      #       dist/x86_64-linux/vorpal
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/aarch64-darwin/vorpal
+            dist/aarch64-linux/vorpal
+            dist/x86_64-darwin/vorpal
+            dist/x86_64-linux/vorpal

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -38,8 +38,6 @@ jobs:
           echo "ARCH=$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/arm64/aarch64/')" >> $GITHUB_ENV
           echo "OS=$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-      - run: ls -alh dist
-
       - uses: actions/upload-artifact@v4
         with:
           name: vorpal-dist-${{ env.ARCH }}-${{ env.OS }}
@@ -52,8 +50,10 @@ jobs:
     strategy:
       matrix:
         runner:
+          - macos-13
           - macos-latest
           - ubuntu-latest
+          - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -161,10 +161,10 @@ jobs:
           mkdir -p dist/aarch64-linux
           mkdir -p dist/x86_64-linux
           mkdir -p dist/x86_64-linux
-          tar -xzf vorpal-aarch64-darwin/vorpal-aarch64-darwin.tar.gz -C dist/aarch64-darwin
-          tar -xzf vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
-          tar -xzf vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
-          tar -xzf vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
+          tar -xzf vorpal-dist-aarch64-darwin/vorpal-aarch64-darwin.tar.gz -C dist/aarch64-darwin
+          tar -xzf vorpal-dist-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
+          tar -xzf vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
+          tar -xzf vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
           ls -alh dist/aarch64-darwin 
           ls -alh dist/aarch64-linux 
           ls -alh dist/x86_64-darwin 

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -26,6 +26,7 @@ jobs:
         runner:
           - macos-latest
           - ubuntu-latest
+          - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -131,6 +132,7 @@ jobs:
           pattern: vorpal-dist-*
 
       - run: |
+          ls -alh
           ls -alh vorpal-dist-arm64-darwin
           ls -alh vorpal-dist-x86_64-linux
 
@@ -148,7 +150,7 @@ jobs:
       #     body: Nightly builds from `main` branch.
       #     fail_on_unmatched_files: true
       #     files: |
-      #       vorpal-dist-arm64-darwin/vorpal-arm64-linux.tar.gz
+      #       vorpal-dist-arm64-darwin/vorpal-arm64-darwin.tar.gz
       #       vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz
       #     name: nightly
       #     prerelease: true

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -159,11 +159,11 @@ jobs:
       - run: |
           mkdir -p dist/aarch64-darwin
           mkdir -p dist/aarch64-linux
-          mkdir -p dist/x86_64-linux
+          mkdir -p dist/x86_64-darwin
           mkdir -p dist/x86_64-linux
           tar -xzf vorpal-dist-aarch64-darwin/vorpal-aarch64-darwin.tar.gz -C dist/aarch64-darwin
           tar -xzf vorpal-dist-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
-          tar -xzf vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
+          tar -xzf vorpal-dist-x86_64-darwin/vorpal-x86_64-darwin.tar.gz -C dist/x86_64-darwin
           tar -xzf vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
           ls -alh dist/aarch64-darwin 
           ls -alh dist/aarch64-linux 

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -130,7 +130,9 @@ jobs:
           fail-on-cache-miss: true
           pattern: vorpal-dist-*
 
-      - run: ls -alh
+      - run: |
+          ls -alh vorpal-dist-arm64-darwin
+          ls -alh vorpal-dist-x86_64-linux
 
       # - env:
       #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -146,8 +148,8 @@ jobs:
       #     body: Nightly builds from `main` branch.
       #     fail_on_unmatched_files: true
       #     files: |
-      #       vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz
-      #       vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz
+      #       vorpal-dist-arm64-darwin/vorpal-arm64-linux.tar.gz
+      #       vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz
       #     name: nightly
       #     prerelease: true
       #     tag_name: refs/tags/nightly

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         runner:
+          - macos-13
           - macos-latest
           - ubuntu-latest
           - ubuntu-latest-arm64
@@ -34,7 +35,11 @@ jobs:
       - run: ./script/dev.sh make dist
 
       - run: |
-          echo "ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+          if [ "$ARCH" = "arm64" ]; then
+            ARCH="aarch64"
+          fi
+          echo "ARCH=$ARCH" >> $GITHUB_ENV
           echo "OS=$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v4
@@ -76,7 +81,11 @@ jobs:
       - run: ./script/install.sh
 
       - run: |
-          echo "ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+          if [ "$ARCH" = "arm64" ]; then
+            ARCH="aarch64"
+          fi
+          echo "ARCH=$ARCH" >> $GITHUB_ENV
           echo "OS=$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v4
@@ -133,7 +142,9 @@ jobs:
 
       - run: |
           ls -alh
-          ls -alh vorpal-dist-arm64-darwin
+          ls -alh vorpal-dist-aarch64-darwin
+          ls -alh vorpal-dist-aarch64-linux
+          ls -alh vorpal-dist-x86_64-darwin
           ls -alh vorpal-dist-x86_64-linux
 
       # - env:
@@ -150,7 +161,8 @@ jobs:
       #     body: Nightly builds from `main` branch.
       #     fail_on_unmatched_files: true
       #     files: |
-      #       vorpal-dist-arm64-darwin/vorpal-arm64-darwin.tar.gz
+      #       vorpal-dist-aarch64-darwin/vorpal-aarch64-darwin.tar.gz
+      #       vorpal-dist-aarch64-linux/vorpal-aarch64-linux.tar.gz
       #       vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz
       #     name: nightly
       #     prerelease: true

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -134,42 +134,46 @@ jobs:
           fail-on-cache-miss: true
           pattern: vorpal-dist-*
 
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view nightly > /dev/null 2>&1; then
+            gh release delete --cleanup-tag --yes nightly
+          fi
+          git tag nightly
+          git push --tags
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          body: Nightly builds from `main` branch.
+          fail_on_unmatched_files: true
+          files: |
+            vorpal-dist-aarch64-darwin/vorpal-aarch64-darwin.tar.gz
+            vorpal-dist-aarch64-linux/vorpal-aarch64-linux.tar.gz
+            vorpal-dist-x86_64-darwin/vorpal-x86_64-darwin.tar.gz
+            vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz
+          name: nightly
+          prerelease: true
+          tag_name: refs/tags/nightly
+
       - run: |
-          ls -alh
-          ls -alh vorpal-dist-aarch64-darwin
-          ls -alh vorpal-dist-aarch64-linux
-          ls -alh vorpal-dist-x86_64-darwin
-          ls -alh vorpal-dist-x86_64-linux
-
-      # - env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     if gh release view nightly > /dev/null 2>&1; then
-      #       gh release delete --cleanup-tag --yes nightly
-      #     fi
-      #     git tag nightly
-      #     git push --tags
-
-      # - uses: softprops/action-gh-release@v2
-      #   with:
-      #     body: Nightly builds from `main` branch.
-      #     fail_on_unmatched_files: true
-      #     files: |
-      #       vorpal-dist-aarch64-darwin/vorpal-aarch64-darwin.tar.gz
-      #       vorpal-dist-aarch64-linux/vorpal-aarch64-linux.tar.gz
-      #       vorpal-dist-x86_64-linux/vorpal-x86_64-linux.tar.gz
-      #     name: nightly
-      #     prerelease: true
-      #     tag_name: refs/tags/nightly
-
-      # - run: |
-      #     mkdir -p dist/aarch64-linux
-      #     mkdir -p dist/x86_64-linux
-      #     tar -xzf vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
-      #     tar -xzf vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
+          mkdir -p dist/aarch64-darwin
+          mkdir -p dist/aarch64-linux
+          mkdir -p dist/x86_64-linux
+          mkdir -p dist/x86_64-linux
+          tar -xzf vorpal-aarch64-darwin/vorpal-aarch64-darwin.tar.gz -C dist/aarch64-darwin
+          tar -xzf vorpal-aarch64-linux/vorpal-aarch64-linux.tar.gz -C dist/aarch64-linux
+          tar -xzf vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
+          tar -xzf vorpal-x86_64-linux/vorpal-x86_64-linux.tar.gz -C dist/x86_64-linux
+          ls -alh dist/aarch64-darwin 
+          ls -alh dist/aarch64-linux 
+          ls -alh dist/x86_64-darwin 
+          ls -alh dist/x86_64-linux 
 
       # - uses: actions/attest-build-provenance@v1
       #   with:
       #     subject-path: |
+      #       dist/aarch64-darwin/vorpal
       #       dist/aarch64-linux/vorpal
+      #       dist/x86_64-darwin/vorpal
       #       dist/x86_64-linux/vorpal

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -42,6 +42,8 @@ jobs:
           echo "ARCH=$ARCH" >> $GITHUB_ENV
           echo "OS=$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
+      - run: ls -alh dist
+
       - uses: actions/upload-artifact@v4
         with:
           name: vorpal-dist-${{ env.ARCH }}-${{ env.OS }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vorpal
 
+I ADDED SOMEHTING TO THE README. PLEASE MAKE SURE THIS IS IN THE COMMIT! THANK YOU!!
+
 Build and ship software with one powerful tool.
 
 ![vorpal-purpose](./vorpal-purpose.jpg)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # vorpal
 
-I ADDED SOMEHTING TO THE README. PLEASE MAKE SURE THIS IS IN THE COMMIT! THANK YOU!!
-
 Build and ship software with one powerful tool.
 
 ![vorpal-purpose](./vorpal-purpose.jpg)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-ARCH := $(shell uname -m | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m | tr '[:upper:]' '[:lower:]' | sed 's/arm64/aarch64/')
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 OS_TYPE ?= debian
 WORK_DIR := $(shell pwd)


### PR DESCRIPTION
## Overview

This closes #131 which implements a simple CI job to release nightly builds for developers to start using Vorpal.
