### PR TITLE
Use os-release to detect distro kind and run a different dev prep script

### DIFF
--- a/script/dev.sh
+++ b/script/dev.sh
@@ -7,7 +7,17 @@ readonly SCRIPT_PATH="${PWD}/script"
 scripts=("rustup" "protoc")
 
 if [[ "$(uname -s)" == "Linux" ]]; then
-    "${SCRIPT_PATH}/dev/debian.sh"
+    . /etc/os-release
+    if [[ "$ID" == "debian" || "$ID" == "ubuntu" ]]; then
+        "${SCRIPT_PATH}/dev/debian.sh"
+    elif [[ "$ID" == "arch" ]]; then
+        "${SCRIPT_PATH}/dev/arch.sh"
+    else
+        echo "Unknown Linux distribution."
+        echo "You will need to install the following manually:"
+        echo ""
+        echo "    bubblewrap ca-certificates curl unzip docker"
+    fi
 fi
 
 mkdir -p "${ENV_PATH}/bin"

--- a/script/dev/arch.sh
+++ b/script/dev/arch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo pacman -S --noconfirm docker bubblewrap ca-certificates curl unzip
+sudo usermod -aG docker $USER


### PR DESCRIPTION
This PR uses [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html) to prepare the dev environment for a different distribution depending on what kind it is, by reading the `ID` variable.

Theoretically we should use `ID_LIKE` for distros like Fedora, RHEL, Rocky Linux, etc. instead because they all have `ID_LIKE="rhel fedora"` or `ID_LIKE="fedora"` etc.