### PR TITLE
Added process management support

### DIFF
--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         runner:
-          # - macos-13
+          - macos-13
           - macos-latest
           - ubuntu-latest
-          # - ubuntu-latest-arm64
+          - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -74,10 +74,10 @@ jobs:
     strategy:
       matrix:
         runner:
-          # - macos-13
+          - macos-13
           - macos-latest
           - ubuntu-latest
-          # - ubuntu-latest-arm64
+          - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -113,10 +113,10 @@ jobs:
     strategy:
       matrix:
         runner:
-          # - macos-13
+          - macos-13
           - macos-latest
           - ubuntu-latest
-          # - ubuntu-latest-arm64
+          - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         runner:
-          - macos-13
+          # - macos-13
           - macos-latest
           - ubuntu-latest
-          - ubuntu-latest-arm64
+          # - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -74,10 +74,10 @@ jobs:
     strategy:
       matrix:
         runner:
-          - macos-13
+          # - macos-13
           - macos-latest
           - ubuntu-latest
-          - ubuntu-latest-arm64
+          # - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -113,10 +113,10 @@ jobs:
     strategy:
       matrix:
         runner:
-          - macos-13
+          # - macos-13
           - macos-latest
           - ubuntu-latest
-          - ubuntu-latest-arm64
+          # - ubuntu-latest-arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -178,12 +178,14 @@ jobs:
           echo "Worker pid: $WORKER_PID"
           sleep 5
 
-      - run: ./dist/vorpal --language "rust" artifact --name "vorpal-shell"
       - run: ./dist/vorpal --language "rust" artifact --name "vorpal"
-      - run: ./dist/vorpal --language "rust" artifact --name "vorpal-example"
-      - run: ./dist/vorpal --language "go" artifact --name "vorpal-shell"
+      - run: ./dist/vorpal --language "rust" artifact --name "vorpal-process"
+      - run: ./dist/vorpal --language "rust" artifact --name "vorpal-shell"
+      - run: ./dist/vorpal --language "rust" artifact --name "vorpal-test"
       - run: ./dist/vorpal --language "go" artifact --name "vorpal"
-      - run: ./dist/vorpal --language "go" artifact --name "vorpal-example"
+      - run: ./dist/vorpal --language "go" artifact --name "vorpal-process"
+      - run: ./dist/vorpal --language "go" artifact --name "vorpal-shell"
+      - run: ./dist/vorpal --language "go" artifact --name "vorpal-test"
 
       - if: always()
         run: |

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -271,7 +271,7 @@ pub async fn build_source(
     if let Some(hash) = source.digest.clone() {
         if hash != source_digest {
             bail!(
-                "'source.{}.hash' mismatch: {} != {}",
+                "'source.{}.digest' mismatch: {} != {}",
                 source.name,
                 source_digest,
                 hash

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -77,6 +77,7 @@ pub async fn get_order(config_artifact: &HashMap<String, Artifact>) -> Result<Ve
 }
 
 pub async fn start(
+    agent: String,
     artifact: String,
     file: String,
     registry: String,
@@ -87,17 +88,23 @@ pub async fn start(
 
     let mut command = process::Command::new(file.clone());
 
-    command.args([
+    let command_port = port.to_string();
+
+    let command_arguments = vec![
         "start",
+        "--agent",
+        &agent,
         "--artifact",
         &artifact,
         "--port",
-        &port.to_string(),
+        &command_port,
         "--registry",
         &registry,
         "--target",
         &target,
-    ]);
+    ];
+
+    command.args(command_arguments);
 
     for var in variable.iter() {
         command.arg("--variable").arg(var);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -188,7 +188,7 @@ async fn main() -> Result<()> {
             // Setup toolchain
 
             let mut config_context = ConfigContext::new(
-                "http://localhost:23151".to_string(),
+                agent.to_string(),
                 config.to_string(),
                 0,
                 registry.to_string(),
@@ -205,8 +205,8 @@ async fn main() -> Result<()> {
                     GoBuilder::new("vorpal-config")
                         .with_artifacts(vec![protoc, protoc_gen_go, protoc_gen_go_grpc])
                         .with_build_directory("sdk/go")
-                        .with_build_script("make generate")
                         .with_includes(vec!["crates/schema/api", "makefile", "sdk/go"])
+                        .with_source_script("make generate")
                         .build(&mut config_context)
                         .await?
                 }
@@ -252,6 +252,7 @@ async fn main() -> Result<()> {
             }
 
             let (mut config_process, mut config_client) = match config::start(
+                agent.to_string(),
                 artifact_name.to_string(),
                 config_path.display().to_string(),
                 registry.clone(),
@@ -396,7 +397,7 @@ async fn main() -> Result<()> {
             let mut router = Server::builder().add_service(health_service);
 
             if services.contains("agent") {
-                let service = AgentServiceServer::new(AgentServer::new(agent.clone()));
+                let service = AgentServiceServer::new(AgentServer::new(registry.clone()));
 
                 info!("agent service: [::]:{}", port);
 

--- a/crates/config/src/main.rs
+++ b/crates/config/src/main.rs
@@ -1,147 +1,21 @@
-use anyhow::Result;
-use indoc::formatdoc;
-use vorpal_sdk::{
-    artifact::{
-        gh, go, goimports, gopls, grpcurl,
-        language::rust::{RustBuilder, RustShellBuilder},
-        protoc, protoc_gen_go, protoc_gen_go_grpc, staticcheck, ArtifactTaskBuilder,
-        VariableBuilder,
-    },
-    context::get_context,
-};
+use anyhow::{bail, Result};
+use vorpal_sdk::context::get_context;
+
+mod vorpal;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let context = &mut get_context().await?;
 
-    // Artifacts
+    let artifact = context.get_artifact_name();
 
-    let gh = gh::build(context).await?;
-    let go = go::build(context).await?;
-    let goimports = goimports::build(context).await?;
-    let gopls = gopls::build(context).await?;
-    let grpcurl = grpcurl::build(context).await?;
-    let protoc = protoc::build(context).await?;
-    let protoc_gen_go = protoc_gen_go::build(context).await?;
-    let protoc_gen_go_grpc = protoc_gen_go_grpc::build(context).await?;
-    let staticcheck = staticcheck::build(context).await?;
-
-    RustShellBuilder::new("vorpal-shell")
-        .with_artifacts(vec![
-            gh.clone(),
-            go,
-            goimports,
-            gopls,
-            grpcurl,
-            protoc.clone(),
-            protoc_gen_go.clone(),
-            protoc_gen_go_grpc.clone(),
-            staticcheck,
-        ])
-        .build(context)
-        .await?;
-
-    let vorpal = RustBuilder::new("vorpal")
-        .with_artifacts(vec![protoc])
-        .with_bins(vec!["vorpal"])
-        .with_packages(vec![
-            "crates/agent",
-            "crates/cli",
-            "crates/registry",
-            "crates/schema",
-            "crates/sdk",
-            "crates/store",
-            "crates/worker",
-        ])
-        .build(context)
-        .await?;
-
-    // Tasks
-
-    match context.get_artifact_name() {
-        "vorpal-example" => {
-            ArtifactTaskBuilder::new("vorpal-example", "vorpal --version".to_string())
-                .with_artifacts(vec![vorpal])
-                .build(context)
-                .await?;
-        }
-
-        "vorpal-release" => {
-            let aarch64_darwin = VariableBuilder::new("aarch64-darwin")
-                .with_require()
-                .build(context)?
-                .unwrap();
-
-            let aarch64_linux = VariableBuilder::new("aarch64-linux")
-                .with_require()
-                .build(context)?
-                .unwrap();
-
-            let branch_name = VariableBuilder::new("branch-name")
-                .with_require()
-                .build(context)?
-                .unwrap();
-
-            let x8664_darwin = VariableBuilder::new("x8664-darwin")
-                .with_require()
-                .build(context)?
-                .unwrap();
-
-            let x8664_linux = VariableBuilder::new("x8664-linux")
-                .with_require()
-                .build(context)?
-                .unwrap();
-
-            // Fetch artifacts
-
-            let aarch64_darwin = context.fetch_artifact(&aarch64_darwin).await?;
-            let aarch64_linux = context.fetch_artifact(&aarch64_linux).await?;
-            let x8664_darwin = context.fetch_artifact(&x8664_darwin).await?;
-            let x8664_linux = context.fetch_artifact(&x8664_linux).await?;
-
-            let artifacts = vec![
-                aarch64_darwin.clone(),
-                aarch64_linux.clone(),
-                gh,
-                x8664_darwin.clone(),
-                x8664_linux.clone(),
-            ];
-
-            let script = formatdoc! {r#"
-                git clone \
-                    --branch {branch_name} \
-                    --depth 1 \
-                    git@github.com:ALT-F4-LLC/vorpal.git
-
-                pushd vorpal
-
-                git fetch --tags
-                git tag --delete nightly || true
-                git push origin :refs/tags/nightly || true
-                gh release delete --yes nightly || true
-
-                git tag nightly
-                git push --tags
-
-                gh release create \
-                    --notes "Nightly builds from main branch." \
-                    --prerelease \
-                    --title "nightly" \
-                    --verify-tag \
-                    nightly \
-                    /var/lib/vorpal/store/{aarch64_darwin}.tar.zst \
-                    /var/lib/vorpal/store/{aarch64_linux}.tar.zst \
-                    /var/lib/vorpal/store/{x8664_darwin}.tar.zst \
-                    /var/lib/vorpal/store/{x8664_linux}.tar.zst"#
-            };
-
-            ArtifactTaskBuilder::new("vorpal-release", script)
-                .with_artifacts(artifacts)
-                .build(context)
-                .await?;
-        }
-
-        _ => {}
+    match artifact {
+        "vorpal" => vorpal::build(context).await?,
+        "vorpal-process" => vorpal::build_process(context).await?,
+        "vorpal-release" => vorpal::build_release(context).await?,
+        "vorpal-shell" => vorpal::build_shell(context).await?,
+        "vorpal-test" => vorpal::build_test(context).await?,
+        _ => bail!("unknown artifact: {}", artifact),
     };
 
     context.run().await

--- a/crates/config/src/vorpal.rs
+++ b/crates/config/src/vorpal.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use indoc::formatdoc;
+use vorpal_sdk::{
+    artifact::{
+        get_env_key, gh, go, goimports, gopls, grpcurl,
+        language::rust::{RustBuilder, RustShellBuilder},
+        nginx, protoc, protoc_gen_go, protoc_gen_go_grpc, staticcheck, ArtifactProcessBuilder,
+        ArtifactTaskBuilder, ArtifactVariableBuilder,
+    },
+    context::ConfigContext,
+};
+
+pub async fn build(context: &mut ConfigContext) -> Result<String> {
+    let protoc = protoc::build(context).await?;
+
+    let name = "vorpal";
+
+    RustBuilder::new(name)
+        .with_artifacts(vec![protoc])
+        .with_bins(vec![name])
+        .with_packages(vec![
+            "crates/agent",
+            "crates/cli",
+            "crates/registry",
+            "crates/schema",
+            "crates/sdk",
+            "crates/store",
+            "crates/worker",
+        ])
+        .build(context)
+        .await
+}
+
+pub async fn build_process(context: &mut ConfigContext) -> Result<String> {
+    let vorpal = build(context).await?;
+
+    let entrypoint = format!("{}/bin/vorpal", get_env_key(&vorpal));
+
+    ArtifactProcessBuilder::new("vorpal-process", entrypoint.as_str())
+        .with_arguments(vec![
+            "--registry",
+            "http://localhost:50051",
+            "start",
+            "--port",
+            "50051",
+        ])
+        .with_artifacts(vec![vorpal])
+        .build(context)
+        .await
+}
+
+pub async fn build_release(context: &mut ConfigContext) -> Result<String> {
+    let aarch64_darwin = ArtifactVariableBuilder::new("aarch64-darwin")
+        .with_require()
+        .build(context)?
+        .unwrap();
+
+    let aarch64_linux = ArtifactVariableBuilder::new("aarch64-linux")
+        .with_require()
+        .build(context)?
+        .unwrap();
+
+    let branch_name = ArtifactVariableBuilder::new("branch-name")
+        .with_require()
+        .build(context)?
+        .unwrap();
+
+    let x8664_darwin = ArtifactVariableBuilder::new("x8664-darwin")
+        .with_require()
+        .build(context)?
+        .unwrap();
+
+    let x8664_linux = ArtifactVariableBuilder::new("x8664-linux")
+        .with_require()
+        .build(context)?
+        .unwrap();
+
+    // Fetch artifacts
+
+    let aarch64_darwin = context.fetch_artifact(&aarch64_darwin).await?;
+    let aarch64_linux = context.fetch_artifact(&aarch64_linux).await?;
+    let gh = gh::build(context).await?;
+    let x8664_darwin = context.fetch_artifact(&x8664_darwin).await?;
+    let x8664_linux = context.fetch_artifact(&x8664_linux).await?;
+
+    let artifacts = vec![
+        aarch64_darwin.clone(),
+        aarch64_linux.clone(),
+        gh,
+        x8664_darwin.clone(),
+        x8664_linux.clone(),
+    ];
+
+    let script = formatdoc! {r#"
+        git clone \
+            --branch {branch_name} \
+            --depth 1 \
+            git@github.com:ALT-F4-LLC/vorpal.git
+
+        pushd vorpal
+
+        git fetch --tags
+        git tag --delete nightly || true
+        git push origin :refs/tags/nightly || true
+        gh release delete --yes nightly || true
+
+        git tag nightly
+        git push --tags
+
+        gh release create \
+            --notes "Nightly builds from main branch." \
+            --prerelease \
+            --title "nightly" \
+            --verify-tag \
+            nightly \
+            {aarch64_darwin}.tar.zst \
+            {aarch64_linux}.tar.zst \
+            {x8664_darwin}.tar.zst \
+            {x8664_linux}.tar.zst"#,
+        aarch64_darwin = get_env_key(&aarch64_darwin),
+        aarch64_linux = get_env_key(&aarch64_linux),
+        x8664_darwin = get_env_key(&x8664_darwin),
+        x8664_linux = get_env_key(&x8664_linux),
+    };
+
+    ArtifactTaskBuilder::new("vorpal-release", script)
+        .with_artifacts(artifacts)
+        .build(context)
+        .await
+}
+
+pub async fn build_shell(context: &mut ConfigContext) -> Result<String> {
+    let gh = gh::build(context).await?;
+    let go = go::build(context).await?;
+    let goimports = goimports::build(context).await?;
+    let gopls = gopls::build(context).await?;
+    let grpcurl = grpcurl::build(context).await?;
+    let nginx = nginx::build(context).await?;
+    let protoc = protoc::build(context).await?;
+    let protoc_gen_go = protoc_gen_go::build(context).await?;
+    let protoc_gen_go_grpc = protoc_gen_go_grpc::build(context).await?;
+    let staticcheck = staticcheck::build(context).await?;
+    let vorpal_process = build_process(context).await?;
+
+    RustShellBuilder::new("vorpal-shell")
+        .with_artifacts(vec![
+            gh,
+            go,
+            goimports,
+            gopls,
+            grpcurl,
+            nginx,
+            protoc,
+            protoc_gen_go,
+            protoc_gen_go_grpc,
+            staticcheck,
+            vorpal_process,
+        ])
+        .build(context)
+        .await
+}
+
+pub async fn build_test(context: &mut ConfigContext) -> Result<String> {
+    let vorpal = build(context).await?;
+
+    let script = format!("{}/bin/vorpal --version", get_env_key(&vorpal));
+
+    ArtifactTaskBuilder::new("vorpal-test", script)
+        .with_artifacts(vec![vorpal])
+        .build(context)
+        .await
+}

--- a/crates/sdk/src/artifact/go.rs
+++ b/crates/sdk/src/artifact/go.rs
@@ -15,7 +15,7 @@ pub async fn build(context: &mut ConfigContext) -> Result<String> {
     let source_digest = match target {
         Aarch64Darwin => "5380e02cdfe2b254af7c3306671fbacc0bfefeb3a9684b502e4af3ad5db917e7",
         Aarch64Linux => "87116daeec496cbc32774c024839ce7a7d0dfced9959fb54527bd55b8890791e",
-        X8664Darwin => "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9",
+        X8664Darwin => "b5903639cc049e527796b8c1330cec3be12ef11d15668c08a1732c03f0cf1dcd",
         X8664Linux => "78181c114c22ddf6413032d5fcc24760a3bee185c35251392fd78691975773aa",
         _ => bail!("unsupported {name} system: {}", target.as_str_name()),
     };

--- a/crates/sdk/src/artifact/go.rs
+++ b/crates/sdk/src/artifact/go.rs
@@ -15,8 +15,8 @@ pub async fn build(context: &mut ConfigContext) -> Result<String> {
     let source_digest = match target {
         Aarch64Darwin => "5380e02cdfe2b254af7c3306671fbacc0bfefeb3a9684b502e4af3ad5db917e7",
         Aarch64Linux => "87116daeec496cbc32774c024839ce7a7d0dfced9959fb54527bd55b8890791e",
-        X8664Darwin => "",
-        X8664Linux => "",
+        X8664Darwin => "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9",
+        X8664Linux => "78181c114c22ddf6413032d5fcc24760a3bee185c35251392fd78691975773aa",
         _ => bail!("unsupported {name} system: {}", target.as_str_name()),
     };
 

--- a/crates/sdk/src/artifact/go.rs
+++ b/crates/sdk/src/artifact/go.rs
@@ -13,10 +13,10 @@ pub async fn build(context: &mut ConfigContext) -> Result<String> {
     let target = context.get_target();
 
     let source_digest = match target {
-        Aarch64Darwin => "86c352c4ced8830cd92a9c85c2944eaa95ebb1e8908b3f01258962bcc94b9c14",
-        Aarch64Linux => "42cec86acdeb62f23b8a65afaa67c2d8c8818f28d7d3ca55430e10e8027a6234",
-        X8664Darwin => "7bd25bbd5d284b8e03fc1581910a5e620c72c4efe235ab44d1f44c8eaed700a9",
-        X8664Linux => "8fb320a301c0cc9fd168e407e4c4b6c46852d753d278d735aa6cae22f3ce82af",
+        Aarch64Darwin => "5380e02cdfe2b254af7c3306671fbacc0bfefeb3a9684b502e4af3ad5db917e7",
+        Aarch64Linux => "87116daeec496cbc32774c024839ce7a7d0dfced9959fb54527bd55b8890791e",
+        X8664Darwin => "",
+        X8664Linux => "",
         _ => bail!("unsupported {name} system: {}", target.as_str_name()),
     };
 
@@ -28,7 +28,7 @@ pub async fn build(context: &mut ConfigContext) -> Result<String> {
         _ => bail!("unsupported {name} system: {}", target.as_str_name()),
     };
 
-    let source_version = "1.23.5";
+    let source_version = "1.24.2";
     let source_path = format!("https://go.dev/dl/go{source_version}.{source_target}.tar.gz");
 
     let source = ArtifactSourceBuilder::new(name, source_path.as_str())

--- a/crates/sdk/src/artifact/nginx.rs
+++ b/crates/sdk/src/artifact/nginx.rs
@@ -1,0 +1,51 @@
+use crate::{
+    artifact::{step, ArtifactBuilder, ArtifactSourceBuilder},
+    context::ConfigContext,
+};
+use anyhow::Result;
+use indoc::formatdoc;
+use vorpal_schema::artifact::v0::ArtifactSystem::{
+    Aarch64Darwin, Aarch64Linux, X8664Darwin, X8664Linux,
+};
+
+pub async fn build(context: &mut ConfigContext) -> Result<String> {
+    let name = "nginx";
+
+    let source_digest = "35764d85e27eac8e8c9eebfe6c5a593224ef63fdd1f2ea0916bf8b4d2335acc0";
+
+    let source_version = "1.27.5";
+
+    let source_path =
+        format!("https://github.com/nginx/nginx/archive/refs/tags/release-{source_version}.tar.gz");
+
+    let source = ArtifactSourceBuilder::new(name, source_path.as_str())
+        .with_digest(source_digest)
+        .build();
+
+    let step_script = formatdoc! {"
+        mkdir -pv \"$VORPAL_OUTPUT/bin\"
+
+        pushd ./source/{name}/nginx-release-{source_version}
+
+        ./auto/configure \
+            --prefix=$VORPAL_OUTPUT \
+            --without-http_rewrite_module
+
+        make
+        make install
+
+        ln -svf $VORPAL_OUTPUT/sbin/nginx $VORPAL_OUTPUT/bin/nginx",
+    };
+
+    let step = step::shell(context, vec![], vec![], step_script).await?;
+
+    ArtifactBuilder::new(name)
+        .with_source(source)
+        .with_step(step)
+        .with_system(Aarch64Darwin)
+        .with_system(Aarch64Linux)
+        .with_system(X8664Darwin)
+        .with_system(X8664Linux)
+        .build(context)
+        .await
+}

--- a/makefile
+++ b/makefile
@@ -92,13 +92,13 @@ generate:
 # Development (with Vorpal)
 
 vorpal:
-	"target/$(TARGET)/vorpal" artifact --name $(ARTIFACT) $(VORPAL_FLAGS)
+	"target/$(TARGET)/vorpal" artifact --name $(VORPAL_ARTIFACT) $(VORPAL_FLAGS)
 
 vorpal-start:
 	"target/$(TARGET)/vorpal" start $(VORPAL_FLAGS)
 
 vorpal-config-start:
-	"$(CONFIG_FILE)" start --artifact "$(ARTIFACT)" --port "50051" $(VORPAL_FLAGS)
+	"$(CONFIG_FILE)" start --artifact "$(VORPAL_ARTIFACT)" --port "50051" $(VORPAL_FLAGS)
 
 # Lima environment
 
@@ -114,7 +114,7 @@ lima: lima-clean
 	limactl start "vorpal-$(LIMA_ARCH)"
 
 lima-vorpal:
-	limactl shell "vorpal-$(LIMA_ARCH)" bash -c '$HOME/vorpal/target/debug/vorpal artifact --name $(ARTIFACT)'
+	limactl shell "vorpal-$(LIMA_ARCH)" bash -c '$HOME/vorpal/target/debug/vorpal artifact --name $(VORPAL_ARTIFACT)'
 
 lima-vorpal-start:
 	limactl shell "vorpal-$(LIMA_ARCH)" bash -c '$HOME/vorpal/target/debug/vorpal start'

--- a/script/lima.sh
+++ b/script/lima.sh
@@ -14,10 +14,7 @@ function sync {
     --delete \
     --exclude=".env" \
     --exclude=".git" \
-    --exclude=".packer" \
-    --exclude=".vagrant" \
     --exclude="dist" \
-    --exclude="packer_debian_vmware_arm64.box" \
     --exclude="target" \
     "$PWD/." "$HOME/vorpal/."
 

--- a/sdk/go/internal/artifact/gobin.go
+++ b/sdk/go/internal/artifact/gobin.go
@@ -14,13 +14,13 @@ func GoBin(context *config.ConfigContext) (*string, error) {
 
 	switch target {
 	case artifact.ArtifactSystem_AARCH64_DARWIN:
-		digest = "6f024d78f0957297229cb00b74b9544fb2c4708a465a584b1e02dfbe5f71922b"
+		digest = "fcbb57571c180e4db1eade2fb51d047083c44ce6acd97d7611d00d15df2d041d"
 	case artifact.ArtifactSystem_AARCH64_LINUX:
-		digest = "42c82308fb915d08bdec4c9bb9d89f4e96fcaaab5e42af9e7e8137880001d1c6"
+		digest = "18887d4facdc3343a40af15e07f753aaab582fbe1f2c5106dbf13a0c221b14e9"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = "ea09f27786bb3eb7d91425c08ac7098b2192c32cbb5c1a2196f5c8e4a9a4d0ff"
+		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = "4712252ab9e5e4bde8909f4aa03460b01d7f3b910c8eea51dec89b55391ae71a"
+		digest = ""
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/gobin.go
+++ b/sdk/go/internal/artifact/gobin.go
@@ -20,7 +20,7 @@ func GoBin(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = ""
+		digest = "219b84a4fe05827674fc1ca51d738026d1f95f27c2487b6218dfc8e8d7779406"
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/gobin.go
+++ b/sdk/go/internal/artifact/gobin.go
@@ -18,7 +18,7 @@ func GoBin(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_AARCH64_LINUX:
 		digest = "18887d4facdc3343a40af15e07f753aaab582fbe1f2c5106dbf13a0c221b14e9"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = ""
+		digest = "24614ca2fd7a86cb515cffa2c519965326ad73fb520c09581eab70623537a041"
 	case artifact.ArtifactSystem_X8664_LINUX:
 		digest = "219b84a4fe05827674fc1ca51d738026d1f95f27c2487b6218dfc8e8d7779406"
 	default:

--- a/sdk/go/internal/artifact/goimports.go
+++ b/sdk/go/internal/artifact/goimports.go
@@ -14,13 +14,13 @@ func Goimports(context *config.ConfigContext) (*string, error) {
 
 	switch target {
 	case artifact.ArtifactSystem_AARCH64_DARWIN:
-		digest = "aca4873c1116603151fd3179855f1000030e10e0428f6e4f8f326bde7f3e74f9"
+		digest = "66a42cc7600ef08f1937ff314c36cceec26451630e83b6c2d6a8f93bf7291b59"
 	case artifact.ArtifactSystem_AARCH64_LINUX:
-		digest = "9072f0f63cb2f4aa6f0b16a6122a986b0852f7acfe47e40e4a6ded3bdf1cb909"
+		digest = "1d48d6a3d0ff9ffa616e6b152c8aa4ca34f4db49e5a9adfdbb0c987235d3aade"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = "8aeeaedcec8d0550f80b469197e5a1ae3b801ef2c27382d0a2b6b62779252011"
+		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = "53a903ec95b4c5c803261d3b74d11bc795990fbf7835fe6a067c8207335cc1f1"
+		digest = ""
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/goimports.go
+++ b/sdk/go/internal/artifact/goimports.go
@@ -20,7 +20,7 @@ func Goimports(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = ""
+		digest = "1ad022e6c026105286866402ca348ccddfd2a56926361dd7b82cc8c26de183c1"
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/goimports.go
+++ b/sdk/go/internal/artifact/goimports.go
@@ -18,7 +18,7 @@ func Goimports(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_AARCH64_LINUX:
 		digest = "1d48d6a3d0ff9ffa616e6b152c8aa4ca34f4db49e5a9adfdbb0c987235d3aade"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = ""
+		digest = "e5d1d90c5d5bc629a25da5e856c6bf5ddc754a46745718c2a60fe8c404819c52"
 	case artifact.ArtifactSystem_X8664_LINUX:
 		digest = "1ad022e6c026105286866402ca348ccddfd2a56926361dd7b82cc8c26de183c1"
 	default:

--- a/sdk/go/internal/artifact/gopls.go
+++ b/sdk/go/internal/artifact/gopls.go
@@ -14,13 +14,13 @@ func Gopls(context *config.ConfigContext) (*string, error) {
 
 	switch target {
 	case artifact.ArtifactSystem_AARCH64_DARWIN:
-		digest = "da002e70fe77900217324968e5a738673bd9a3b005d53f9455c8852ac5a2a315"
+		digest = "6d597686fa68271ef9367eae65aa6cf997e48def78a941a93aea4c96183b457a"
 	case artifact.ArtifactSystem_AARCH64_LINUX:
-		digest = "00f678057bbc3e7fa6e2df780c8064e751cae19c8406c1c1ab96de8a1a43b66d"
+		digest = "2bdbb5ae2632da58df6087b959cf7e6867c2ad534297428de22877de32aea5ca"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = "3d8e33d7eceeb1556f7cd31e6464f30330499538e389532110c38bb541fd4930"
+		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = "fc473a2d04a3ccff623d23bd9bcfd38347e7bfc5de0a5b390941a1808f1758ce"
+		digest = ""
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/gopls.go
+++ b/sdk/go/internal/artifact/gopls.go
@@ -18,7 +18,7 @@ func Gopls(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_AARCH64_LINUX:
 		digest = "2bdbb5ae2632da58df6087b959cf7e6867c2ad534297428de22877de32aea5ca"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = ""
+		digest = "e994de43d344c304ab9bcf835965c5c25678b926980420400f6d530faea0185b"
 	case artifact.ArtifactSystem_X8664_LINUX:
 		digest = "761fcbb77a80c668982e378e4e9bc5c03183c4e7cc70aa13660176422093aa3c"
 	default:

--- a/sdk/go/internal/artifact/gopls.go
+++ b/sdk/go/internal/artifact/gopls.go
@@ -20,7 +20,7 @@ func Gopls(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = ""
+		digest = "761fcbb77a80c668982e378e4e9bc5c03183c4e7cc70aa13660176422093aa3c"
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/grpcurl.go
+++ b/sdk/go/internal/artifact/grpcurl.go
@@ -20,7 +20,7 @@ func Grpcurl(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = ""
+		digest = "22c3ed96cbd3e6fcec8b424e91ecd9f8b332a92e372c159f2edc0ec8f34f6c27"
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/grpcurl.go
+++ b/sdk/go/internal/artifact/grpcurl.go
@@ -18,7 +18,7 @@ func Grpcurl(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_AARCH64_LINUX:
 		digest = "109a4ed11d63bf7f9afbd819342ef8e2988873ee146e525d65e7416928855ddf"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = ""
+		digest = "b8dacfe7be0747a87bc1278bbb3ff2179702314de3cac74f75ee61047786350b"
 	case artifact.ArtifactSystem_X8664_LINUX:
 		digest = "22c3ed96cbd3e6fcec8b424e91ecd9f8b332a92e372c159f2edc0ec8f34f6c27"
 	default:

--- a/sdk/go/internal/artifact/grpcurl.go
+++ b/sdk/go/internal/artifact/grpcurl.go
@@ -14,13 +14,13 @@ func Grpcurl(context *config.ConfigContext) (*string, error) {
 
 	switch target {
 	case artifact.ArtifactSystem_AARCH64_DARWIN:
-		digest = "aaa487c3dc4092aac62818b332e9569a57f89af773aaa574015e766a692e5670"
+		digest = "292c9b6a2d40fcddf8add7533c96951e0d60d756b4a57c72093ab4be74bb0ce7"
 	case artifact.ArtifactSystem_AARCH64_LINUX:
-		digest = "3c05329da72f300dc01be7fef11ce7e9e4beb1c300098c9cedcfdecc99d4318b"
+		digest = "109a4ed11d63bf7f9afbd819342ef8e2988873ee146e525d65e7416928855ddf"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = "8d0257c581b2021a49a97cbbc2f77891bda0eb0f7d0c4dffd9fe166fa00b1db7"
+		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = "7753f7c7187a34e769d9b2d649a58b13a093a00f76c71a632ec797d4e779d0c4"
+		digest = ""
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/nginx.go
+++ b/sdk/go/internal/artifact/nginx.go
@@ -20,7 +20,7 @@ func Nginx(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = ""
+		digest = "19f8c5223fcbc5db0316dedc205505e30e1475e3c35e9178533fba00b5e5006d"
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/nginx.go
+++ b/sdk/go/internal/artifact/nginx.go
@@ -7,16 +7,16 @@ import (
 	"github.com/ALT-F4-LLC/vorpal/sdk/go/internal/config"
 )
 
-func Staticcheck(context *config.ConfigContext) (*string, error) {
+func Nginx(context *config.ConfigContext) (*string, error) {
 	target := context.GetTarget()
 
 	var digest string
 
 	switch target {
 	case artifact.ArtifactSystem_AARCH64_DARWIN:
-		digest = "d06c462ddccb64f6838276c9bcd987f65411c95d2fd9b7944d070e6014f7c40b"
+		digest = "5a78e58e9dbc4915194b7ce68bcddf4b70e212a81813a66f5f3e47d84332ccfa"
 	case artifact.ArtifactSystem_AARCH64_LINUX:
-		digest = "3d8dd1e8d2040415cfda963b56d6acaf888415c697b4c315ca186a88858eab87"
+		digest = "26a9f79b00db4e79b25511b739bccb2ca34f6374c539a33954c234b53f282d52"
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:

--- a/sdk/go/internal/artifact/nginx.go
+++ b/sdk/go/internal/artifact/nginx.go
@@ -18,7 +18,7 @@ func Nginx(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_AARCH64_LINUX:
 		digest = "26a9f79b00db4e79b25511b739bccb2ca34f6374c539a33954c234b53f282d52"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = ""
+		digest = "12d14d4d5675e5c17ac1d47fd6b69813bab2814b93c17a10b83857cafdff1671"
 	case artifact.ArtifactSystem_X8664_LINUX:
 		digest = "19f8c5223fcbc5db0316dedc205505e30e1475e3c35e9178533fba00b5e5006d"
 	default:

--- a/sdk/go/internal/artifact/protoc_gen_go_grpc.go
+++ b/sdk/go/internal/artifact/protoc_gen_go_grpc.go
@@ -14,13 +14,13 @@ func ProtocGenGoGRPC(context *config.ConfigContext) (*string, error) {
 
 	switch target {
 	case artifact.ArtifactSystem_AARCH64_DARWIN:
-		digest = "22f504b558607cb98545fd4a119d9aa2c8afdf1d5abe930fca8f7f67a638326b"
+		digest = "410549ec26b1b169c64ca0d4b6c09987000b0e88b7854a608708806c58a13dcc"
 	case artifact.ArtifactSystem_AARCH64_LINUX:
-		digest = "3c3a7674049be0e8babb4feac647af64bc070a2d0fdfe1f329ee4f99710676d0"
+		digest = "0197068bfea81502d1e152c4bc4c4e5584c191d5931b9f68dc1ac5f3aa9a67a4"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = "82cf321054f629ee489e0df282975e8b2eed47f2376cc59606589510e70d0e14"
+		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = "54b67d3c7eab2d300826028ef649eb14e1f2f1a80e2a895338b453c30e311973"
+		digest = ""
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/protoc_gen_go_grpc.go
+++ b/sdk/go/internal/artifact/protoc_gen_go_grpc.go
@@ -20,7 +20,7 @@ func ProtocGenGoGRPC(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = ""
+		digest = "ed50829e4f561a392881bb81b10c6617e7ecf08a0dc8a06e9515c559f51f3ffa"
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/artifact/protoc_gen_go_grpc.go
+++ b/sdk/go/internal/artifact/protoc_gen_go_grpc.go
@@ -18,7 +18,7 @@ func ProtocGenGoGRPC(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_AARCH64_LINUX:
 		digest = "0197068bfea81502d1e152c4bc4c4e5584c191d5931b9f68dc1ac5f3aa9a67a4"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = ""
+		digest = "ee3fee174a60350ba21e971557b2ae189fc7674127d6e528fd78aa8d151d98c8"
 	case artifact.ArtifactSystem_X8664_LINUX:
 		digest = "ed50829e4f561a392881bb81b10c6617e7ecf08a0dc8a06e9515c559f51f3ffa"
 	default:

--- a/sdk/go/internal/artifact/staticcheck.go
+++ b/sdk/go/internal/artifact/staticcheck.go
@@ -18,7 +18,7 @@ func Staticcheck(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_AARCH64_LINUX:
 		digest = "3d8dd1e8d2040415cfda963b56d6acaf888415c697b4c315ca186a88858eab87"
 	case artifact.ArtifactSystem_X8664_DARWIN:
-		digest = ""
+		digest = "d81cc5e018b5b65f6f26a17440a317fefd6bfc26a3cd62316bf92d57aafa837f"
 	case artifact.ArtifactSystem_X8664_LINUX:
 		digest = "d88da046d4fdc9833f4577263f0144cdda8e4014627232e2bcf9f9a85889fa0d"
 	default:

--- a/sdk/go/internal/artifact/staticcheck.go
+++ b/sdk/go/internal/artifact/staticcheck.go
@@ -20,7 +20,7 @@ func Staticcheck(context *config.ConfigContext) (*string, error) {
 	case artifact.ArtifactSystem_X8664_DARWIN:
 		digest = ""
 	case artifact.ArtifactSystem_X8664_LINUX:
-		digest = ""
+		digest = "d88da046d4fdc9833f4577263f0144cdda8e4014627232e2bcf9f9a85889fa0d"
 	default:
 		return nil, errors.New("unsupported target")
 	}

--- a/sdk/go/internal/config/cli.go
+++ b/sdk/go/internal/config/cli.go
@@ -23,10 +23,10 @@ func newCommand() (*command, error) {
 
 	var startVariable []string
 
-	startAgent := startCmd.String("agent", "localhost:23151", "agent to use")
+	startAgent := startCmd.String("agent", "http://localhost:23151", "agent to use")
 	startArtifact := startCmd.String("artifact", "", "artifact to use")
 	startPort := startCmd.Int("port", 0, "port to listen on")
-	startRegistry := startCmd.String("registry", "localhost:23151", "registry to use")
+	startRegistry := startCmd.String("registry", "http://localhost:23151", "registry to use")
 	startTarget := startCmd.String("target", GetSystemDefaultStr(), "target system")
 	startCmd.Var(newStringSliceValue(&startVariable), "variable", "variables to use (key=value)")
 

--- a/sdk/go/internal/config/context.go
+++ b/sdk/go/internal/config/context.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 
 	agentApi "github.com/ALT-F4-LLC/vorpal/sdk/go/api/v0/agent"
 	artifactApi "github.com/ALT-F4-LLC/vorpal/sdk/go/api/v0/artifact"
@@ -125,7 +126,9 @@ func (c *ConfigContext) AddArtifact(artifact *artifactApi.Artifact) (*string, er
 
 	// TODO: make this run in parallel
 
-	clientConn, err := grpc.NewClient(c.agent, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	agent := strings.ReplaceAll(c.agent, "http://", "")
+
+	clientConn, err := grpc.NewClient(agent, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +203,9 @@ func (c *ConfigContext) FetchArtifact(digest string) (*string, error) {
 		return &digest, nil
 	}
 
-	clientConn, err := grpc.NewClient(c.agent, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	registry := strings.ReplaceAll(c.registry, "http://", "")
+
+	clientConn, err := grpc.NewClient(registry, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/main.go
+++ b/sdk/go/main.go
@@ -1,242 +1,33 @@
 package main
 
 import (
-	"bytes"
 	"log"
-	"text/template"
 
-	"github.com/ALT-F4-LLC/vorpal/sdk/go/internal/artifact"
-	"github.com/ALT-F4-LLC/vorpal/sdk/go/internal/artifact/language"
 	"github.com/ALT-F4-LLC/vorpal/sdk/go/internal/config"
 )
 
-type ReleaseScriptTemplateArgs struct {
-	Aarch64Darwin string
-	Aarch64Linux  string
-	BranchName    string
-	X8664Darwin   string
-	X8664Linux    string
-}
-
-const ReleaseScriptTemplate = `
-git clone \
-    --branch {{.BranchName}} \
-    --depth 1 \
-    git@github.com:ALT-F4-LLC/vorpal.git
-
-pushd vorpal
-
-git fetch --tags
-git tag --delete nightly || true
-git push origin :refs/tags/nightly || true
-gh release delete --yes nightly || true
-
-git tag nightly
-git push --tags
-
-gh release create \
-    --notes "Nightly builds from main branch." \
-    --prerelease \
-    --title "nightly" \
-    --verify-tag \
-    nightly \
-    /var/lib/vorpal/store/{{.Aarch64Darwin}}.tar.zst`
-
 func main() {
 	context := config.GetContext()
+	contextArtifact := context.GetArtifactName()
 
-	// Artifacts
+	var err error
 
-	gh, err := artifact.Gh(context)
-	if err != nil {
-		log.Fatalf("failed to get gh artifact: %v", err)
-	}
-
-	gobin, err := artifact.GoBin(context)
-	if err != nil {
-		log.Fatalf("failed to get gobin artifact: %v", err)
-	}
-
-	goimports, err := artifact.Goimports(context)
-	if err != nil {
-		log.Fatalf("failed to get goimports artifact: %v", err)
-	}
-
-	gopls, err := artifact.Gopls(context)
-	if err != nil {
-		log.Fatalf("failed to get gopls artifact: %v", err)
-	}
-
-	grpcurl, err := artifact.Grpcurl(context)
-	if err != nil {
-		log.Fatalf("failed to get grpcurl artifact: %v", err)
-	}
-
-	protoc, err := artifact.Protoc(context)
-	if err != nil {
-		log.Fatalf("failed to get protoc artifact: %v", err)
-	}
-
-	protocGenGo, err := artifact.ProtocGenGo(context)
-	if err != nil {
-		log.Fatalf("failed to get protoc-gen-go artifact: %v", err)
-	}
-
-	protocGenGoGRPC, err := artifact.ProtocGenGoGRPC(context)
-	if err != nil {
-		log.Fatalf("failed to get protoc-gen-go-grpc artifact: %v", err)
-	}
-
-	staticcheck, err := artifact.Staticcheck(context)
-	if err != nil {
-		log.Fatalf("failed to get staticcheck artifact: %v", err)
-	}
-
-	_, err = language.NewRustShellBuilder("vorpal-shell").
-		WithArtifacts([]*string{
-			gh,
-			gobin,
-			goimports,
-			gopls,
-			grpcurl,
-			protoc,
-			protocGenGo,
-			protocGenGoGRPC,
-			staticcheck,
-		}).
-		Build(context)
-	if err != nil {
-		log.Fatalf("failed to create vorpal shell artifact: %v", err)
-	}
-
-	vorpal, err := language.NewRustBuilder("vorpal").
-		WithArtifacts([]*string{
-			protoc,
-		}).
-		WithBins([]string{
-			"vorpal",
-		}).
-		WithPackages([]string{
-			"crates/agent",
-			"crates/cli",
-			"crates/registry",
-			"crates/schema",
-			"crates/sdk",
-			"crates/store",
-			"crates/worker",
-		}).
-		Build(context)
-	if err != nil {
-		log.Fatalf("failed to create vorpal artifact: %v", err)
-	}
-
-	// Tasks
-
-	switch context.GetArtifactName() {
-	case "vorpal-example":
-		_, err = artifact.NewArtifactTaskBuilder("vorpal-example", "\nvorpal --version").
-			WithArtifacts([]*string{
-				vorpal,
-			}).
-			Build(context)
-		if err != nil {
-			log.Fatalf("failed to create vorpal-example artifact: %v", err)
-		}
-
+	switch contextArtifact {
+	case "vorpal":
+		_, err = build(context)
+	case "vorpal-process":
+		_, err = buildProcess(context)
 	case "vorpal-release":
-		varAarch64Darwin, err := artifact.
-			NewVariableBuilder("aarch64-darwin").
-			WithRequire().
-			Build(context)
-		if err != nil {
-			log.Fatalf("failed to get aarch64-darwin artifact: %v", err)
-		}
-
-		varAarch64Linux, err := artifact.
-			NewVariableBuilder("aarch64-linux").
-			WithRequire().
-			Build(context)
-		if err != nil {
-			log.Fatalf("failed to get aarch64-linux artifact: %v", err)
-		}
-
-		varBranchName, err := artifact.
-			NewVariableBuilder("branch-name").
-			WithRequire().
-			Build(context)
-		if err != nil {
-			log.Fatalf("failed to get branch-name artifact: %v", err)
-		}
-
-		varX8664Darwin, err := artifact.
-			NewVariableBuilder("x8664-darwin").
-			WithRequire().
-			Build(context)
-		if err != nil {
-			log.Fatalf("failed to get x8664-darwin artifact: %v", err)
-		}
-
-		varX8664Linux, err := artifact.
-			NewVariableBuilder("x8664-linux").
-			WithRequire().
-			Build(context)
-		if err != nil {
-			log.Fatalf("failed to get x8664-linux artifact: %v", err)
-		}
-
-		aarch64Darwin, err := context.FetchArtifact(*varAarch64Darwin)
-		if err != nil {
-			log.Fatalf("failed to fetch aarch64-darwin artifact: %v", err)
-		}
-
-		aarch64Linux, err := context.FetchArtifact(*varAarch64Linux)
-		if err != nil {
-			log.Fatalf("failed to fetch aarch64-linux artifact: %v", err)
-		}
-
-		x8664Darwin, err := context.FetchArtifact(*varX8664Darwin)
-		if err != nil {
-			log.Fatalf("failed to fetch x8664-darwin artifact: %v", err)
-		}
-
-		x8664Linux, err := context.FetchArtifact(*varX8664Linux)
-		if err != nil {
-			log.Fatalf("failed to fetch x8664-linux artifact: %v", err)
-		}
-
-		artifacts := []*string{
-			aarch64Darwin,
-			aarch64Linux,
-			gh,
-			x8664Darwin,
-			x8664Linux,
-		}
-
-		scriptTemplate, err := template.New("script").Parse(ReleaseScriptTemplate)
-		if err != nil {
-			log.Fatalf("failed to parse script template: %v", err)
-		}
-
-		var scriptBuffer bytes.Buffer
-
-		scriptTemplateVars := ReleaseScriptTemplateArgs{
-			Aarch64Darwin: *aarch64Darwin,
-			Aarch64Linux:  *aarch64Linux,
-			BranchName:    *varBranchName,
-			X8664Darwin:   *x8664Darwin,
-			X8664Linux:    *x8664Linux,
-		}
-
-		if err := scriptTemplate.Execute(&scriptBuffer, scriptTemplateVars); err != nil {
-			log.Fatalf("failed to execute script template: %v", err)
-		}
-
-		_, err = artifact.NewArtifactTaskBuilder("vorpal-release", scriptBuffer.String()).
-			WithArtifacts(artifacts).
-			Build(context)
-		if err != nil {
-			log.Fatalf("failed to create vorpal-release artifact: %v", err)
-		}
+		_, err = buildRelease(context)
+	case "vorpal-shell":
+		_, err = buildShell(context)
+	case "vorpal-test":
+		_, err = buildTest(context)
+	default:
+		log.Fatalf("unknown artifact %s", contextArtifact)
+	}
+	if err != nil {
+		log.Fatalf("failed to build artifact %s: %v", contextArtifact, err)
 	}
 
 	context.Run()

--- a/sdk/go/vorpal.go
+++ b/sdk/go/vorpal.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/ALT-F4-LLC/vorpal/sdk/go/internal/artifact"
+	"github.com/ALT-F4-LLC/vorpal/sdk/go/internal/artifact/language"
+	"github.com/ALT-F4-LLC/vorpal/sdk/go/internal/config"
+)
+
+type ReleaseScriptTemplateArgs struct {
+	Aarch64Darwin string
+	Aarch64Linux  string
+	BranchName    string
+	X8664Darwin   string
+	X8664Linux    string
+}
+
+const ReleaseScriptTemplate = `
+git clone \
+    --branch {{.BranchName}} \
+    --depth 1 \
+    git@github.com:ALT-F4-LLC/vorpal.git
+
+pushd vorpal
+
+git fetch --tags
+git tag --delete nightly || true
+git push origin :refs/tags/nightly || true
+gh release delete --yes nightly || true
+
+git tag nightly
+git push --tags
+
+gh release create \
+    --notes "Nightly builds from main branch." \
+    --prerelease \
+    --title "nightly" \
+    --verify-tag \
+    nightly \
+    /var/lib/vorpal/store/{{.Aarch64Darwin}}.tar.zst`
+
+func build(context *config.ConfigContext) (*string, error) {
+	protoc, err := artifact.Protoc(context)
+	if err != nil {
+		return nil, err
+	}
+
+	name := "vorpal"
+
+	return language.NewRustBuilder(name).
+		WithArtifacts([]*string{protoc}).
+		WithBins([]string{name}).
+		WithPackages([]string{
+			"crates/agent",
+			"crates/cli",
+			"crates/registry",
+			"crates/schema",
+			"crates/sdk",
+			"crates/store",
+			"crates/worker",
+		}).
+		Build(context)
+}
+
+func buildProcess(context *config.ConfigContext) (*string, error) {
+	vorpal, err := build(context)
+	if err != nil {
+		return nil, err
+	}
+
+	entrypoint := fmt.Sprintf("%s/bin/vorpal", artifact.GetEnvKey(vorpal))
+
+	return artifact.NewArtifactProcessBuilder("vorpal-process", entrypoint).
+		WithArguments([]string{
+			"--registry",
+			"http://localhost:50051",
+			"start",
+			"--port",
+			"50051",
+		}).
+		WithArtifacts([]*string{vorpal}).
+		Build(context)
+}
+
+func buildRelease(context *config.ConfigContext) (*string, error) {
+	varAarch64Darwin, err := artifact.
+		NewArtifactVariableBuilder("aarch64-darwin").
+		WithRequire().
+		Build(context)
+	if err != nil {
+		return nil, err
+	}
+
+	varAarch64Linux, err := artifact.
+		NewArtifactVariableBuilder("aarch64-linux").
+		WithRequire().
+		Build(context)
+	if err != nil {
+		return nil, err
+	}
+
+	varBranchName, err := artifact.
+		NewArtifactVariableBuilder("branch-name").
+		WithRequire().
+		Build(context)
+	if err != nil {
+		return nil, err
+	}
+
+	varX8664Darwin, err := artifact.
+		NewArtifactVariableBuilder("x8664-darwin").
+		WithRequire().
+		Build(context)
+	if err != nil {
+		return nil, err
+	}
+
+	varX8664Linux, err := artifact.
+		NewArtifactVariableBuilder("x8664-linux").
+		WithRequire().
+		Build(context)
+	if err != nil {
+		return nil, err
+	}
+
+	aarch64Darwin, err := context.FetchArtifact(*varAarch64Darwin)
+	if err != nil {
+		return nil, err
+	}
+
+	aarch64Linux, err := context.FetchArtifact(*varAarch64Linux)
+	if err != nil {
+		return nil, err
+	}
+
+	gh, err := artifact.Gh(context)
+	if err != nil {
+		return nil, err
+	}
+
+	x8664Darwin, err := context.FetchArtifact(*varX8664Darwin)
+	if err != nil {
+		return nil, err
+	}
+
+	x8664Linux, err := context.FetchArtifact(*varX8664Linux)
+	if err != nil {
+		return nil, err
+	}
+
+	artifacts := []*string{
+		aarch64Darwin,
+		aarch64Linux,
+		gh,
+		x8664Darwin,
+		x8664Linux,
+	}
+
+	scriptTemplate, err := template.New("script").Parse(ReleaseScriptTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	var scriptBuffer bytes.Buffer
+
+	scriptTemplateVars := ReleaseScriptTemplateArgs{
+		Aarch64Darwin: *aarch64Darwin,
+		Aarch64Linux:  *aarch64Linux,
+		BranchName:    *varBranchName,
+		X8664Darwin:   *x8664Darwin,
+		X8664Linux:    *x8664Linux,
+	}
+
+	if err := scriptTemplate.Execute(&scriptBuffer, scriptTemplateVars); err != nil {
+		return nil, err
+	}
+
+	return artifact.NewArtifactTaskBuilder("vorpal-release", scriptBuffer.String()).
+		WithArtifacts(artifacts).
+		Build(context)
+}
+
+func buildShell(context *config.ConfigContext) (*string, error) {
+	gh, err := artifact.Gh(context)
+	if err != nil {
+		return nil, err
+	}
+
+	gobin, err := artifact.GoBin(context)
+	if err != nil {
+		return nil, err
+	}
+
+	goimports, err := artifact.Goimports(context)
+	if err != nil {
+		return nil, err
+	}
+
+	gopls, err := artifact.Gopls(context)
+	if err != nil {
+		return nil, err
+	}
+
+	grpcurl, err := artifact.Grpcurl(context)
+	if err != nil {
+		return nil, err
+	}
+
+	protoc, err := artifact.Protoc(context)
+	if err != nil {
+		return nil, err
+	}
+
+	protocGenGo, err := artifact.ProtocGenGo(context)
+	if err != nil {
+		return nil, err
+	}
+
+	protocGenGoGRPC, err := artifact.ProtocGenGoGRPC(context)
+	if err != nil {
+		return nil, err
+	}
+
+	staticcheck, err := artifact.Staticcheck(context)
+	if err != nil {
+		return nil, err
+	}
+
+	vorpalProcess, err := buildProcess(context)
+	if err != nil {
+		return nil, err
+	}
+
+	nginx, err := artifact.Nginx(context)
+	if err != nil {
+		return nil, err
+	}
+
+	return language.NewRustShellBuilder("vorpal-shell").
+		WithArtifacts([]*string{
+			gh,
+			gobin,
+			goimports,
+			gopls,
+			grpcurl,
+			nginx,
+			protoc,
+			protocGenGo,
+			protocGenGoGRPC,
+			staticcheck,
+			vorpalProcess,
+		}).
+		Build(context)
+}
+
+func buildTest(context *config.ConfigContext) (*string, error) {
+	vorpal, err := build(context)
+	if err != nil {
+		return nil, err
+	}
+
+	script := fmt.Sprintf("\n%s/bin/vorpal --version", artifact.GetEnvKey(vorpal))
+
+	return artifact.NewArtifactTaskBuilder("vorpal-test", script).
+		WithArtifacts([]*string{vorpal}).
+		Build(context)
+}


### PR DESCRIPTION
## Changes

- added `ArtifactProcessBuilder` to SDKs

## Example

```rust
let entrypoint = format!("{}/bin/vorpal", get_env_key(&vorpal));

ArtifactProcessBuilder::new("vorpal-process", entrypoint.as_str())
    .with_arguments(vec![
        "--registry",
        "http://localhost:50051",
        "start",
        "--port",
        "50051",
    ])
    .with_artifacts(vec![vorpal])
    .build(context)
    .await
```

Closes #200 