### PR TITLE
Support Bearer token

### DIFF
--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -207,7 +207,7 @@ jobs:
           path: Vorpal.lock
 
   release:
-    # if: github.event.schedule != ''
+    if: github.event.schedule != ''
     needs:
       - test
     permissions:

--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -207,7 +207,7 @@ jobs:
           path: Vorpal.lock
 
   release:
-    if: github.event.schedule != ''
+    if: github.event_name == 'schedule'
     needs:
       - test
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,7 +3865,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vorpal-cli"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-config"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "home",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-sdk"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-cli"
 publish = false
-version = "0.1.0-rc.1"
+version = "0.1.0"
 
 [[bin]]
 name = "vorpal"

--- a/cli/src/command/artifact/inspect.rs
+++ b/cli/src/command/artifact/inspect.rs
@@ -54,7 +54,7 @@ pub async fn run(digest: &str, registry: &str, api_token: Option<String>) -> Res
 
     grpc_request.metadata_mut().insert(
         "authorization",
-        user_api_token
+        format!("Bearer {}", user_api_token)
             .parse()
             .expect("failed to set authorization header"),
     );

--- a/cli/src/command/artifact/make.rs
+++ b/cli/src/command/artifact/make.rs
@@ -91,10 +91,12 @@ async fn build(
 
     request.metadata_mut().insert(
         "authorization",
-        user_api_token
+        format!("Bearer {}", user_api_token)
             .parse()
             .expect("failed to set authorization header"),
     );
+
+    // TODO: add check before pulling
 
     match client_archive.pull(request).await {
         Err(status) => {
@@ -170,7 +172,7 @@ async fn build(
 
     request.metadata_mut().insert(
         "authorization",
-        user_api_token
+        format!("Bearer {}", user_api_token)
             .parse()
             .expect("failed to set authorization header"),
     );

--- a/cli/src/command/start.rs
+++ b/cli/src/command/start.rs
@@ -65,7 +65,7 @@ pub async fn run(
 
     let service_secret = auth::load_service_secret().await?;
 
-    let auth_interceptor = auth::create_auth_interceptor(service_secret);
+    let auth_interceptor = auth::create_interceptor(service_secret);
 
     if services.contains(&"agent".to_string()) {
         let service = AgentServiceServer::with_interceptor(

--- a/cli/src/command/start/agent.rs
+++ b/cli/src/command/start/agent.rs
@@ -84,7 +84,7 @@ pub async fn build_source(
         .await
         .map_err(|e| anyhow!("failed to connect to registry: {}", e))?;
 
-    let auth_header: MetadataValue<_> = service_secret
+    let auth_header: MetadataValue<_> = format!("Bearer {}", service_secret)
         .parse()
         .map_err(|e| anyhow!("failed to parse service secret: {}", e))?;
 

--- a/cli/src/command/start/worker.rs
+++ b/cli/src/command/start/worker.rs
@@ -114,7 +114,7 @@ async fn pull_source(
             Status::internal(format!("failed to create archive client channel: {err}"))
         })?;
 
-    let auth_header: MetadataValue<_> = service_secret
+    let auth_header: MetadataValue<_> = format!("Bearer {}", service_secret)
         .parse()
         .map_err(|e| Status::internal(format!("failed to parse service secret: {}", e)))?;
 
@@ -624,8 +624,7 @@ async fn build_artifact(
                 Status::internal(format!("failed to create archive client channel: {err}"))
             })?;
 
-        let auth_header_push: MetadataValue<_> = service_secret
-            .clone()
+        let auth_header_push: MetadataValue<_> = format!("Bearer {}", service_secret.clone())
             .parse()
             .map_err(|e| Status::internal(format!("failed to parse service secret: {}", e)))?;
 
@@ -703,7 +702,7 @@ async fn build_artifact(
                 Status::internal(format!("failed to create artifact client channel: {err}"))
             })?;
 
-        let auth_header: MetadataValue<_> = service_secret
+        let auth_header: MetadataValue<_> = format!("Bearer {}", service_secret)
             .parse()
             .map_err(|e| Status::internal(format!("failed to parse service secret: {}", e)))?;
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-config"
 publish = false
-version = "0.1.0-rc.1"
+version = "0.1.0"
 
 [[bin]]
 name = "vorpal-config"

--- a/script/dev/terraform.sh
+++ b/script/dev/terraform.sh
@@ -5,7 +5,7 @@ ARCH="$(uname -m | tr '[:upper:]' '[:lower:]')"
 OS="$(uname | tr '[:upper:]' '[:lower:]')"
 TERRAFORM_ARCH=""
 TERRAFORM_OS=""
-TERRAFORM_VERSION="1.13.0"
+TERRAFORM_VERSION="1.13.3"
 
 case "${OS}" in
   darwin|linux)

--- a/sdk/go/pkg/config/auth.go
+++ b/sdk/go/pkg/config/auth.go
@@ -12,20 +12,20 @@ import (
 
 // AuthInterceptor creates a gRPC client interceptor that adds authorization headers
 func AuthInterceptor(secret string) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		// Add authorization header to the context
-		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", secret)
-		return invoker(ctx, method, req, reply, cc, opts...)
-	}
+    return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+        // Add authorization header with Bearer scheme
+        ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+secret)
+        return invoker(ctx, method, req, reply, cc, opts...)
+    }
 }
 
 // StreamAuthInterceptor creates a gRPC client stream interceptor that adds authorization headers
 func StreamAuthInterceptor(secret string) grpc.StreamClientInterceptor {
-	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		// Add authorization header to the context
-		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", secret)
-		return streamer(ctx, desc, cc, method, opts...)
-	}
+    return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+        // Add authorization header with Bearer scheme
+        ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+secret)
+        return streamer(ctx, desc, cc, method, opts...)
+    }
 }
 
 // LoadClientAPIToken loads the user API token from VORPAL_API_TOKEN environment variable

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "vorpal-sdk"
 repository = "https://github.com/ALT-F4-LLC/vorpal"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 
 [dependencies]
 anyhow = { version = "1.0.98" }

--- a/sdk/rust/src/context.rs
+++ b/sdk/rust/src/context.rs
@@ -224,7 +224,7 @@ impl ConfigContext {
 
         request.metadata_mut().insert(
             "authorization",
-            self.client_api_token
+            format!("Bearer {}", self.client_api_token)
                 .parse()
                 .expect("failed to set authorization header"),
         );
@@ -303,7 +303,7 @@ impl ConfigContext {
 
             grpc_request.metadata_mut().insert(
                 "authorization",
-                self.client_api_token
+                format!("Bearer {}", self.client_api_token)
                     .parse()
                     .expect("failed to set authorization header"),
             );
@@ -344,7 +344,7 @@ impl ConfigContext {
 
         grpc_request.metadata_mut().insert(
             "authorization",
-            self.client_api_token
+            format!("Bearer {}", self.client_api_token)
                 .parse()
                 .expect("failed to set authorization header"),
         );
@@ -369,7 +369,7 @@ impl ConfigContext {
 
                 grpc_request.metadata_mut().insert(
                     "authorization",
-                    self.client_api_token
+                    format!("Bearer {}", self.client_api_token)
                         .parse()
                         .expect("failed to set authorization header"),
                 );


### PR DESCRIPTION
## Changes

- this uses the `Bearer <token>` prefix for the authorization metadata