### PR TITLE
Update installation script URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ flowchart LR
 
 ## Setup
 ### Install (prebuilt binaries):
-  - `curl -fsSL https://github.com/ALT-F4-LLC/vorpal/blob/main/script/install.sh -o install.sh && sh install.sh`
+  - `curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/refs/heads/main/script/install.sh -o install.sh && sh install.sh`
 
 ### Build from source (macOS & Linux):
   - macOS only (once): `xcode-select --install`


### PR DESCRIPTION
Currently, the install line points to the GitHub page link. When curling such a url, GitHub will return an HTML page. This PR changes the URL to point to raw.githubusercontent, which is a domain under which GitHub returns raw content of the file, more suitable to do one-liners.