### PR TITLE
Change ExecStart command for vorpal service in install.sh

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -99,7 +99,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=${INSTALL_DIR}/bin/vorpal start
+ExecStart=${INSTALL_DIR}/bin/vorpal services start
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
Currently, install script is using old CLI, therefore systemd unit is failing after the installation. 
This PR changes the install script to use `services start` instead of just `start`