### PR TITLE
Add support for different root directories

### DIFF
--- a/cli/src/command/store/paths.rs
+++ b/cli/src/command/store/paths.rs
@@ -8,8 +8,19 @@ use walkdir::WalkDir;
 
 // Root paths
 
+const DEFAULT_ROOT_DIR_PATH: &'static str = "/var/bin/vorpal";
+
 pub fn get_root_dir_path() -> PathBuf {
-    Path::new("/var/lib/vorpal").to_path_buf()
+    let path = match std::env::var("VORPAL_ROOT_PATH") {
+        Ok(value) => PathBuf::from(value),
+        Err(std::env::VarError::NotUnicode(os_string)) => PathBuf::from(os_string),
+        Err(std::env::VarError::NotPresent) => PathBuf::from(DEFAULT_ROOT_DIR_PATH)
+    };
+    if !path.exists() {
+        // TODO: Initialize root directory?
+        panic!("Vorpal root directory ({}) does not exist", path.to_string_lossy())
+    }
+    path
 }
 
 pub fn get_root_key_dir_path() -> PathBuf {


### PR DESCRIPTION
Currently, vorpal will always try to write to `/var/lib/vorpal` (to my understanding). This PR allows the root directory to be set using `VORPAL_ROOT_PATH` env variable.
Use case:
In some cases, for example, when running not under root or in a MapReduce job, access to the outer file system may be limited or non-existent at all. In such cases, this will allow setting the workdir to a user-writable scratch directory.