### PR TITLE
Migrate SDK sources

### DIFF
--- a/.github/workflows/vorpal.yaml
+++ b/.github/workflows/vorpal.yaml
@@ -516,7 +516,7 @@ jobs:
   #
   #     - uses: oven-sh/setup-bun@v2
   #
-  #     - run: bun install
+  #     - run: bun install --frozen-lockfile
   #       working-directory: sdk/typescript
   #
   #     - run: bun run build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,11 +522,11 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -733,9 +733,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -826,7 +826,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1042,7 +1042,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1507,7 +1507,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1738,16 +1738,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1959,7 +1958,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -2066,9 +2065,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "liblzma"
@@ -2102,7 +2101,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -2143,9 +2142,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2520,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2536,7 +2535,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f0d4202cea786c2aa44e20692eb5dfac74f0d3804d2ce68fdbd40bedcbef05"
 dependencies = [
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2647,7 +2646,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "memchr",
  "unicase",
 ]
@@ -2673,7 +2672,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -2690,10 +2689,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2750,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2760,13 +2759,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2809,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rcgen"
@@ -2843,7 +2842,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2852,7 +2851,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2905,14 +2904,14 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3006,7 +3005,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3027,16 +3026,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.11",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -3075,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3160,7 +3159,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3616,9 +3615,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3657,7 +3656,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -3849,7 +3848,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -4040,7 +4039,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vorpal-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4066,7 +4065,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rsa",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -4090,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "indoc",
@@ -4100,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4124,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-sdk-codegen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4263,7 +4262,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4617,7 +4616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Vorpal.lock
+++ b/Vorpal.lock
@@ -9,6 +9,14 @@ digest = "8e8da18fe5560d744bd6ca32d4128badb699394567b6b7ae18b8a734268655a4"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "bash"
+path = "https://sdk.vorpal.build/source/bash-5.3.tar.gz"
+includes = []
+excludes = []
+digest = "8e8da18fe5560d744bd6ca32d4128badb699394567b6b7ae18b8a734268655a4"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "binutils"
 path = "https://sdk.vorpal.build/source/binutils-2.45.tar.gz"
 includes = []
@@ -17,12 +25,28 @@ digest = "ef4e00c3b96def973211d311ea2874d15f2bbcdce670053759bf09584db2d545"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "binutils"
+path = "https://sdk.vorpal.build/source/binutils-2.45.tar.gz"
+includes = []
+excludes = []
+digest = "ef4e00c3b96def973211d311ea2874d15f2bbcdce670053759bf09584db2d545"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "bison"
 path = "https://sdk.vorpal.build/source/bison-3.8.2.tar.gz"
 includes = []
 excludes = []
 digest = "cb18c2c8562fc01bf3ae17ffe9cf8274e3dd49d39f89397c1a8bac7ee14ce85f"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "bison"
+path = "https://sdk.vorpal.build/source/bison-3.8.2.tar.gz"
+includes = []
+excludes = []
+digest = "cb18c2c8562fc01bf3ae17ffe9cf8274e3dd49d39f89397c1a8bac7ee14ce85f"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "bun"
@@ -39,6 +63,22 @@ includes = []
 excludes = []
 digest = "93bb13af9d1586c92a61b6afb94a21ef632b88a9510b56c9102f5ab09f34db89"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "bun"
+path = "https://sdk.vorpal.build/source/bun-1.3.10-linux-x64-baseline.zip"
+includes = []
+excludes = []
+digest = "f95e1d566deb62fadd810aa6d2e6dd61ef7623989a3ab14884ed0868814b1b6f"
+platform = "x86_64-linux"
+
+[[sources]]
+name = "cargo"
+path = "https://sdk.vorpal.build/source/cargo-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
+includes = []
+excludes = []
+digest = "379b758b6be27ddd82ce70a5bbdb4bfe1030cd535271377f8fd51a426080ddee"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "cargo"
@@ -73,12 +113,28 @@ digest = "4c20fc23ed2870442608ced8a9e9c314a4b27fe78fed356e0092efd377c44681"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "clippy"
+path = "https://sdk.vorpal.build/source/clippy-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
+includes = []
+excludes = []
+digest = "a5515f5ede4c8c2c751647e710747a021e22df00d6c80778628cded51d24ec70"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "coreutils"
 path = "https://sdk.vorpal.build/source/coreutils-9.7.tar.gz"
 includes = []
 excludes = []
 digest = "a7abdad032ae6c318dbb4c9b444d9031ab34d1308700005c4bd5eb5156cad523"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "coreutils"
+path = "https://sdk.vorpal.build/source/coreutils-9.7.tar.gz"
+includes = []
+excludes = []
+digest = "a7abdad032ae6c318dbb4c9b444d9031ab34d1308700005c4bd5eb5156cad523"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "crane"
@@ -97,12 +153,28 @@ digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "crane"
+path = "https://sdk.vorpal.build/source/crane-v0.21.1.tar.gz"
+includes = []
+excludes = []
+digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "curl"
 path = "https://sdk.vorpal.build/source/curl-8.15.0.tar.xz"
 includes = []
 excludes = []
 digest = "565e83672abb0ba470bbfcb07f49877b54abc68a51c4dd7831c61129fed9e244"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "curl"
+path = "https://sdk.vorpal.build/source/curl-8.15.0.tar.xz"
+includes = []
+excludes = []
+digest = "565e83672abb0ba470bbfcb07f49877b54abc68a51c4dd7831c61129fed9e244"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "curl-cacert"
@@ -113,12 +185,28 @@ digest = "2f4bfe5eb47cf2325d70469a0488a20d0b451d622c5b4bbf02935c5661d9de36"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "curl-cacert"
+path = "https://sdk.vorpal.build/source/cacert-1776122862.pem"
+includes = []
+excludes = []
+digest = "2f4bfe5eb47cf2325d70469a0488a20d0b451d622c5b4bbf02935c5661d9de36"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "diffutils"
 path = "https://sdk.vorpal.build/source/diffutils-3.12.tar.xz"
 includes = []
 excludes = []
 digest = "7e416707fa95ffddaae20d11541834bad8d6df24b6bcc8044c2f16a7fb27755e"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "diffutils"
+path = "https://sdk.vorpal.build/source/diffutils-3.12.tar.xz"
+includes = []
+excludes = []
+digest = "7e416707fa95ffddaae20d11541834bad8d6df24b6bcc8044c2f16a7fb27755e"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "file"
@@ -129,12 +217,28 @@ digest = "07a8a2f5e1458359d20f420865e4a246c55c1b85176274dfee81e109e9789fb2"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "file"
+path = "https://sdk.vorpal.build/source/file-5.46.tar.gz"
+includes = []
+excludes = []
+digest = "07a8a2f5e1458359d20f420865e4a246c55c1b85176274dfee81e109e9789fb2"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "findutils"
 path = "https://sdk.vorpal.build/source/findutils-4.10.0.tar.xz"
 includes = []
 excludes = []
 digest = "242f804d87a5036bb0fab99966227dc61e853e5a67e1b10c3cc45681c792657e"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "findutils"
+path = "https://sdk.vorpal.build/source/findutils-4.10.0.tar.xz"
+includes = []
+excludes = []
+digest = "242f804d87a5036bb0fab99966227dc61e853e5a67e1b10c3cc45681c792657e"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "gawk"
@@ -145,6 +249,14 @@ digest = "33ad80dd59a028d9ac67cffeb9cb35483b268c530bd90d18bb245596d3847103"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "gawk"
+path = "https://sdk.vorpal.build/source/gawk-5.3.2.tar.gz"
+includes = []
+excludes = []
+digest = "33ad80dd59a028d9ac67cffeb9cb35483b268c530bd90d18bb245596d3847103"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "gcc"
 path = "https://sdk.vorpal.build/source/gcc-15.2.0.tar.xz"
 includes = []
@@ -153,12 +265,36 @@ digest = "cf322f18454e1f54a0ebf661b4c3b556de43651aea8bc7a3bb14ee3863ed56d4"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "gcc"
+path = "https://sdk.vorpal.build/source/gcc-15.2.0.tar.xz"
+includes = []
+excludes = []
+digest = "cf322f18454e1f54a0ebf661b4c3b556de43651aea8bc7a3bb14ee3863ed56d4"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "gettext"
 path = "https://sdk.vorpal.build/source/gettext-0.26.tar.gz"
 includes = []
 excludes = []
 digest = "459265943fcb010124e5056bfff3e9fc95d571f3abef9d022b0af18cbc282b02"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "gettext"
+path = "https://sdk.vorpal.build/source/gettext-0.26.tar.gz"
+includes = []
+excludes = []
+digest = "459265943fcb010124e5056bfff3e9fc95d571f3abef9d022b0af18cbc282b02"
+platform = "x86_64-linux"
+
+[[sources]]
+name = "gh"
+path = "https://sdk.vorpal.build/source/gh_2.87.3_linux_amd64.tar.gz"
+includes = []
+excludes = []
+digest = "6582f9d01e650e6c90965fbe5c00417e3c2c6f3f1eab330bbf15be83818f9851"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "gh"
@@ -193,12 +329,28 @@ digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "git"
+path = "https://sdk.vorpal.build/source/git-2.53.0.tar.gz"
+includes = []
+excludes = []
+digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "glibc"
 path = "https://sdk.vorpal.build/source/glibc-2.42.tar.gz"
 includes = []
 excludes = []
 digest = "ce551ab3767e6b55726d763a14f98bfc4bff9ebcd3516f478885408e454942b1"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "glibc"
+path = "https://sdk.vorpal.build/source/glibc-2.42.tar.gz"
+includes = []
+excludes = []
+digest = "ce551ab3767e6b55726d763a14f98bfc4bff9ebcd3516f478885408e454942b1"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "glibc-patch"
@@ -209,12 +361,28 @@ digest = "69cf0653ad0a6a178366d291f30629d4e1cb633178aa4b8efbea0c851fb944ca"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "glibc-patch"
+path = "https://sdk.vorpal.build/source/glibc-2.42-fhs-1.patch"
+includes = []
+excludes = []
+digest = "69cf0653ad0a6a178366d291f30629d4e1cb633178aa4b8efbea0c851fb944ca"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "gmp"
 path = "https://sdk.vorpal.build/source/gmp-6.3.0.tar.gz"
 includes = []
 excludes = []
 digest = "191226cef6e9ce60e291e178db47682aadea28cb3e92f35f006ba317f3e10195"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "gmp"
+path = "https://sdk.vorpal.build/source/gmp-6.3.0.tar.gz"
+includes = []
+excludes = []
+digest = "191226cef6e9ce60e291e178db47682aadea28cb3e92f35f006ba317f3e10195"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "go"
@@ -233,6 +401,14 @@ digest = "bcee4e23358013d48b6ad5eb2152dc64dc320d7a6dfac8ed56767f2243b0213a"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "go"
+path = "https://sdk.vorpal.build/source/go1.26.0.linux-amd64.tar.gz"
+includes = []
+excludes = []
+digest = "d23a8bd1d7050453d53bcb13271e7682a176463a6f53992b1a2cedf17310ef30"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "goimports"
 path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
 includes = []
@@ -249,6 +425,14 @@ digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "goimports"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
+includes = []
+excludes = []
+digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "gopls"
 path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
 includes = []
@@ -263,6 +447,14 @@ includes = []
 excludes = []
 digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "gopls"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
+includes = []
+excludes = []
+digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "grep"
@@ -273,6 +465,14 @@ digest = "127096050676822f1f9f18e2bdf847f74907ec691562959cdcbf07e7d524012c"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "grep"
+path = "https://sdk.vorpal.build/source/grep-3.12.tar.gz"
+includes = []
+excludes = []
+digest = "127096050676822f1f9f18e2bdf847f74907ec691562959cdcbf07e7d524012c"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "grpcurl"
 path = "https://sdk.vorpal.build/source/grpcurl-v1.9.3.tar.gz"
 includes = []
@@ -289,12 +489,28 @@ digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "grpcurl"
+path = "https://sdk.vorpal.build/source/grpcurl-v1.9.3.tar.gz"
+includes = []
+excludes = []
+digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "gzip"
 path = "https://sdk.vorpal.build/source/gzip-1.14.tar.gz"
 includes = []
 excludes = []
 digest = "82c708cb0f1ae98c1bcd38edb744ece2cc13cbbd65379a11ff030f86a140ce3d"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "gzip"
+path = "https://sdk.vorpal.build/source/gzip-1.14.tar.gz"
+includes = []
+excludes = []
+digest = "82c708cb0f1ae98c1bcd38edb744ece2cc13cbbd65379a11ff030f86a140ce3d"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "libidn2"
@@ -305,12 +521,28 @@ digest = "a5a46eb63af153ca526f17133b2f5be09bc434b7cdc25f924a2580b879ab9b9c"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "libidn2"
+path = "https://sdk.vorpal.build/source/libidn2-2.3.8.tar.gz"
+includes = []
+excludes = []
+digest = "a5a46eb63af153ca526f17133b2f5be09bc434b7cdc25f924a2580b879ab9b9c"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "libpsl"
 path = "https://sdk.vorpal.build/source/libpsl-0.21.5.tar.gz"
 includes = []
 excludes = []
 digest = "65ecfe61646c50119a018a2003149833c11387efd92462f974f1ff9f907c1d78"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "libpsl"
+path = "https://sdk.vorpal.build/source/libpsl-0.21.5.tar.gz"
+includes = []
+excludes = []
+digest = "65ecfe61646c50119a018a2003149833c11387efd92462f974f1ff9f907c1d78"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "libunistring"
@@ -321,12 +553,28 @@ digest = "e9d4afe75ff42ffce5e55c7267a45d2b6a2c3909d8d8e1ba09cdb99f28896b4d"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "libunistring"
+path = "https://sdk.vorpal.build/source/libunistring-1.3.tar.gz"
+includes = []
+excludes = []
+digest = "e9d4afe75ff42ffce5e55c7267a45d2b6a2c3909d8d8e1ba09cdb99f28896b4d"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "linux"
 path = "https://sdk.vorpal.build/source/linux-6.16.1.tar.xz"
 includes = []
 excludes = []
 digest = "40d7204e3d3f1112f0fb32d32cd18421db103a8564c7b277c2b83d54df5b2ff2"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "linux"
+path = "https://sdk.vorpal.build/source/linux-6.16.1.tar.xz"
+includes = []
+excludes = []
+digest = "40d7204e3d3f1112f0fb32d32cd18421db103a8564c7b277c2b83d54df5b2ff2"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "m4"
@@ -337,12 +585,28 @@ digest = "633adb94257b39e0e3f9785ea7ccad7ce9b31b22914fdacdcc5accf2b09fba16"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "m4"
+path = "https://sdk.vorpal.build/source/m4-1.4.20.tar.gz"
+includes = []
+excludes = []
+digest = "633adb94257b39e0e3f9785ea7ccad7ce9b31b22914fdacdcc5accf2b09fba16"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "make"
 path = "https://sdk.vorpal.build/source/make-4.4.1.tar.gz"
 includes = []
 excludes = []
 digest = "8dfe7b0e51b3e190cd75e046880855ac1be76cf36961e5cfcc82bfa91b2c3ba8"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "make"
+path = "https://sdk.vorpal.build/source/make-4.4.1.tar.gz"
+includes = []
+excludes = []
+digest = "8dfe7b0e51b3e190cd75e046880855ac1be76cf36961e5cfcc82bfa91b2c3ba8"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "mpc"
@@ -353,6 +617,14 @@ digest = "c179fbcd6e48931a16c0af37d0c4a5e1688dd07d71e2b4a532c68cd5edbb5b72"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "mpc"
+path = "https://sdk.vorpal.build/source/mpc-1.3.1.tar.gz"
+includes = []
+excludes = []
+digest = "c179fbcd6e48931a16c0af37d0c4a5e1688dd07d71e2b4a532c68cd5edbb5b72"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "mpfr"
 path = "https://sdk.vorpal.build/source/mpfr-4.2.2.tar.xz"
 includes = []
@@ -361,12 +633,28 @@ digest = "837f1bf914eb615761136e6bcd2d49502865b18c0f0d18b4decb513355c4449b"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "mpfr"
+path = "https://sdk.vorpal.build/source/mpfr-4.2.2.tar.xz"
+includes = []
+excludes = []
+digest = "837f1bf914eb615761136e6bcd2d49502865b18c0f0d18b4decb513355c4449b"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "ncurses"
 path = "https://sdk.vorpal.build/source/ncurses-6.5-20250809.tar.gz"
 includes = []
 excludes = []
 digest = "e67077219f4e56cc6cc56958104a9271871ef65ef7985081aced1fd5024f9f47"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "ncurses"
+path = "https://sdk.vorpal.build/source/ncurses-6.5-20250809.tar.gz"
+includes = []
+excludes = []
+digest = "e67077219f4e56cc6cc56958104a9271871ef65ef7985081aced1fd5024f9f47"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "nodejs"
@@ -385,12 +673,28 @@ digest = "852a244f9da062f7d22326a7bc3d7836745521232bd44b06468ec48e1cf359e4"
 platform = "aarch64-darwin"
 
 [[sources]]
+name = "nodejs"
+path = "https://sdk.vorpal.build/source/node-v22.22.0-linux-x64.tar.gz"
+includes = []
+excludes = []
+digest = "85e8bfadee08751035db748cfe0e6f2cd99cfe4ed854b1ac2fb253ada3f13765"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "openssl"
 path = "https://sdk.vorpal.build/source/openssl-3.5.2.tar.gz"
 includes = []
 excludes = []
 digest = "c18db5dccbd9ee71d1454dbf275b508c1fa452b133f0e8e9812d6f8135c29362"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "openssl"
+path = "https://sdk.vorpal.build/source/openssl-3.5.2.tar.gz"
+includes = []
+excludes = []
+digest = "c18db5dccbd9ee71d1454dbf275b508c1fa452b133f0e8e9812d6f8135c29362"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "patch"
@@ -401,12 +705,28 @@ digest = "a003cf376248ecf2dc3edbce55f672f7677ff95ef94dd7ce6fdcef8353ecde7c"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "patch"
+path = "https://sdk.vorpal.build/source/patch-2.8.tar.gz"
+includes = []
+excludes = []
+digest = "a003cf376248ecf2dc3edbce55f672f7677ff95ef94dd7ce6fdcef8353ecde7c"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "perl"
 path = "https://sdk.vorpal.build/source/perl-5.42.0.tar.xz"
 includes = []
 excludes = []
 digest = "43a6f8cf15fcedeb66e95c4957ec8bc43db40515de89483e507c01c255fce853"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "perl"
+path = "https://sdk.vorpal.build/source/perl-5.42.0.tar.xz"
+includes = []
+excludes = []
+digest = "43a6f8cf15fcedeb66e95c4957ec8bc43db40515de89483e507c01c255fce853"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "pnpm"
@@ -418,11 +738,27 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "pnpm"
+path = "https://sdk.vorpal.build/source/pnpm-10.30.3-linux-x64"
+includes = []
+excludes = []
+digest = "8c460b3846f657c7833bc8a42c1ae30c48ef81f1d80adeb41139c7204b4ea129"
+platform = "x86_64-linux"
+
+[[sources]]
+name = "pnpm"
 path = "https://sdk.vorpal.build/source/pnpm-10.30.3-linux-arm64"
 includes = []
 excludes = []
 digest = "9f21233c7a93c57224f3fdadc52a5f581fae63eacf2a2a521bc4e8495f3e3630"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "protoc"
+path = "https://sdk.vorpal.build/source/protoc-34.0-linux-x86_64.zip"
+includes = []
+excludes = []
+digest = "72ef7563c9bc34409ec1bbc2632479a47a1c99e458346fcb7f4e1ca0c2f4f008"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "protoc"
@@ -450,6 +786,14 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "protoc-gen-go"
+path = "https://sdk.vorpal.build/source/protoc-gen-go.v1.36.11.linux.amd64.tar.gz"
+includes = []
+excludes = []
+digest = "72d35ffffc54b7024a90a0ca8ad2dde80f08822918ba8c52b2d3c0698f5d2d3a"
+platform = "x86_64-linux"
+
+[[sources]]
+name = "protoc-gen-go"
 path = "https://sdk.vorpal.build/source/protoc-gen-go.v1.36.11.linux.arm64.tar.gz"
 includes = []
 excludes = []
@@ -473,12 +817,28 @@ digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "protoc-gen-go-grpc"
+path = "https://sdk.vorpal.build/source/protoc-gen-go-grpc-v1.79.1.tar.gz"
+includes = []
+excludes = []
+digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "python"
 path = "https://sdk.vorpal.build/source/Python-3.13.7.tar.xz"
 includes = []
 excludes = []
 digest = "2118e11e9ee7b73a88e2fb7c9122455c314660de29beb4d4f15af2d21e15ec42"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "python"
+path = "https://sdk.vorpal.build/source/Python-3.13.7.tar.xz"
+includes = []
+excludes = []
+digest = "2118e11e9ee7b73a88e2fb7c9122455c314660de29beb4d4f15af2d21e15ec42"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "rsync"
@@ -495,6 +855,14 @@ includes = []
 excludes = []
 digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "rsync"
+path = "https://sdk.vorpal.build/source/rsync-3.4.1.tar.gz"
+includes = []
+excludes = []
+digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "rust-analyzer"
@@ -513,6 +881,14 @@ digest = "5389db13945d33e320e4ddb44c558fda83923ceeac0d9931d6deae8ec2373bd6"
 platform = "aarch64-darwin"
 
 [[sources]]
+name = "rust-analyzer"
+path = "https://sdk.vorpal.build/source/rust-analyzer-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
+includes = []
+excludes = []
+digest = "edac8e06763f599243d084d763d28ebc0fc4e2022b2bc235645c8e490b3044ca"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "rust-src"
 path = "https://sdk.vorpal.build/source/rust-src-1.93.1.tar.gz"
 includes = []
@@ -527,6 +903,14 @@ includes = []
 excludes = []
 digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "rust-src"
+path = "https://sdk.vorpal.build/source/rust-src-1.93.1.tar.gz"
+includes = []
+excludes = []
+digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "rust-std"
@@ -545,6 +929,14 @@ digest = "a1f91e63d9d4183645c49505752051c052b9b59a0a949de04673132bdcd85345"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "rust-std"
+path = "https://sdk.vorpal.build/source/rust-std-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
+includes = []
+excludes = []
+digest = "d2a48d1e65027c3382c76850179f85ac03c25f318adbf2a97f5b02271bb1eacf"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "rustc"
 path = "https://sdk.vorpal.build/source/rustc-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
 includes = []
@@ -559,6 +951,22 @@ includes = []
 excludes = []
 digest = "53c9d5b83e6f2c6b826d29043e36c104a179cc8eeb354424d1799632ec82bd3a"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "rustc"
+path = "https://sdk.vorpal.build/source/rustc-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
+includes = []
+excludes = []
+digest = "6ff1c992044553d46afbcb9bf352ceb64a82c9d454bbba78eaf555e7d24bc685"
+platform = "x86_64-linux"
+
+[[sources]]
+name = "rustfmt"
+path = "https://sdk.vorpal.build/source/rustfmt-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
+includes = []
+excludes = []
+digest = "0c45566683fa70ae7dad317a2d9ef510a16a012cb4240dbd12a69e36ed543fab"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "rustfmt"
@@ -585,6 +993,14 @@ digest = "434ff552af89340088e0d8cb206c251761297909bbee401176bc8f655e8e7cf2"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "sed"
+path = "https://sdk.vorpal.build/source/sed-4.9.tar.gz"
+includes = []
+excludes = []
+digest = "434ff552af89340088e0d8cb206c251761297909bbee401176bc8f655e8e7cf2"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "staticcheck"
 path = "https://sdk.vorpal.build/source/staticcheck-2026.1.tar.gz"
 includes = []
@@ -601,12 +1017,28 @@ digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "staticcheck"
+path = "https://sdk.vorpal.build/source/staticcheck-2026.1.tar.gz"
+includes = []
+excludes = []
+digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "tar"
 path = "https://sdk.vorpal.build/source/tar-1.35.tar.gz"
 includes = []
 excludes = []
 digest = "f9bb5f39ed45b1c6a324470515d2ef73e74422c5f345503106d861576d3f02f3"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "tar"
+path = "https://sdk.vorpal.build/source/tar-1.35.tar.gz"
+includes = []
+excludes = []
+digest = "f9bb5f39ed45b1c6a324470515d2ef73e74422c5f345503106d861576d3f02f3"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "texinfo"
@@ -617,12 +1049,28 @@ digest = "6bc4aa1be570367196b2488d4783f02dae702822db9d2aa9e5d650339e0f770e"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "texinfo"
+path = "https://sdk.vorpal.build/source/texinfo-7.2.tar.gz"
+includes = []
+excludes = []
+digest = "6bc4aa1be570367196b2488d4783f02dae702822db9d2aa9e5d650339e0f770e"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "unzip"
 path = "https://sdk.vorpal.build/source/unzip60.tar.gz"
 includes = []
 excludes = []
 digest = "4585067be297ae977da3f81587fcf0a141a8d6ceb6137d199255683ed189c3ed"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "unzip"
+path = "https://sdk.vorpal.build/source/unzip60.tar.gz"
+includes = []
+excludes = []
+digest = "4585067be297ae977da3f81587fcf0a141a8d6ceb6137d199255683ed189c3ed"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "unzip-patch-fixes"
@@ -633,12 +1081,28 @@ digest = "11350935be5bbb743f1a97ec069b78fc2904f92b24abbc7fb3d7f0ff8bb889ea"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "unzip-patch-fixes"
+path = "https://sdk.vorpal.build/source/unzip-6.0-consolidated_fixes-1.patch"
+includes = []
+excludes = []
+digest = "11350935be5bbb743f1a97ec069b78fc2904f92b24abbc7fb3d7f0ff8bb889ea"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "unzip-patch-gcc14"
 path = "https://sdk.vorpal.build/source/unzip-6.0-gcc14-1.patch"
 includes = []
 excludes = []
 digest = "d6ac941672086ea4c8d5047d550b40047825a685cc7c48626d2f0939e1a0c797"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "unzip-patch-gcc14"
+path = "https://sdk.vorpal.build/source/unzip-6.0-gcc14-1.patch"
+includes = []
+excludes = []
+digest = "d6ac941672086ea4c8d5047d550b40047825a685cc7c48626d2f0939e1a0c797"
+platform = "x86_64-linux"
 
 [[sources]]
 name = "util-linux"
@@ -649,6 +1113,14 @@ digest = "1f10bfbd4ac7b3e8058fe837b0ed9274d2b3f603dc2d7cbc3d325dc612b06aaa"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "util-linux"
+path = "https://sdk.vorpal.build/source/util-linux-2.41.1.tar.xz"
+includes = []
+excludes = []
+digest = "1f10bfbd4ac7b3e8058fe837b0ed9274d2b3f603dc2d7cbc3d325dc612b06aaa"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "xz"
 path = "https://sdk.vorpal.build/source/xz-5.8.1.tar.xz"
 includes = []
@@ -657,9 +1129,25 @@ digest = "24827cfbd8504ed6499a08262caf7d4c4584a5ee2505843526f0f020daf9ab93"
 platform = "aarch64-linux"
 
 [[sources]]
+name = "xz"
+path = "https://sdk.vorpal.build/source/xz-5.8.1.tar.xz"
+includes = []
+excludes = []
+digest = "24827cfbd8504ed6499a08262caf7d4c4584a5ee2505843526f0f020daf9ab93"
+platform = "x86_64-linux"
+
+[[sources]]
 name = "zlib"
 path = "https://sdk.vorpal.build/source/zlib-1.3.1.tar.gz"
 includes = []
 excludes = []
 digest = "3f7995d5f103719283f509c23624287ce95c349439e881ed935a3c2c807bb683"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "zlib"
+path = "https://sdk.vorpal.build/source/zlib-1.3.1.tar.gz"
+includes = []
+excludes = []
+digest = "3f7995d5f103719283f509c23624287ce95c349439e881ed935a3c2c807bb683"
+platform = "x86_64-linux"

--- a/Vorpal.lock
+++ b/Vorpal.lock
@@ -2,15 +2,7 @@ lockfile = 1
 
 [[sources]]
 name = "bash"
-path = "https://ftpmirror.gnu.org/gnu/bash/bash-5.3.tar.gz"
-includes = []
-excludes = []
-digest = "8e8da18fe5560d744bd6ca32d4128badb699394567b6b7ae18b8a734268655a4"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "bash"
-path = "https://ftpmirror.gnu.org/gnu/bash/bash-5.3.tar.gz"
+path = "https://sdk.vorpal.build/source/bash-5.3.tar.gz"
 includes = []
 excludes = []
 digest = "8e8da18fe5560d744bd6ca32d4128badb699394567b6b7ae18b8a734268655a4"
@@ -18,15 +10,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "binutils"
-path = "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.gz"
-includes = []
-excludes = []
-digest = "ef4e00c3b96def973211d311ea2874d15f2bbcdce670053759bf09584db2d545"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "binutils"
-path = "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.gz"
+path = "https://sdk.vorpal.build/source/binutils-2.45.tar.gz"
 includes = []
 excludes = []
 digest = "ef4e00c3b96def973211d311ea2874d15f2bbcdce670053759bf09584db2d545"
@@ -34,15 +18,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "bison"
-path = "https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
-includes = []
-excludes = []
-digest = "cb18c2c8562fc01bf3ae17ffe9cf8274e3dd49d39f89397c1a8bac7ee14ce85f"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "bison"
-path = "https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
+path = "https://sdk.vorpal.build/source/bison-3.8.2.tar.gz"
 includes = []
 excludes = []
 digest = "cb18c2c8562fc01bf3ae17ffe9cf8274e3dd49d39f89397c1a8bac7ee14ce85f"
@@ -50,7 +26,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "bun"
-path = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.10/bun-darwin-aarch64.zip"
+path = "https://sdk.vorpal.build/source/bun-1.3.10-darwin-aarch64.zip"
 includes = []
 excludes = []
 digest = "93bb13af9d1586c92a61b6afb94a21ef632b88a9510b56c9102f5ab09f34db89"
@@ -58,15 +34,7 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "cargo"
-path = "https://static.rust-lang.org/dist/cargo-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
-includes = []
-excludes = []
-digest = "379b758b6be27ddd82ce70a5bbdb4bfe1030cd535271377f8fd51a426080ddee"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "cargo"
-path = "https://static.rust-lang.org/dist/cargo-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
+path = "https://sdk.vorpal.build/source/cargo-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
 includes = []
 excludes = []
 digest = "6b773215302a46b6cfd565539dabc0af9dad01bdd9c37587e7041907ab5b9212"
@@ -74,15 +42,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "cargo"
-path = "https://static.rust-lang.org/dist/cargo-1.93.1-x86_64-apple-darwin.tar.gz"
-includes = []
-excludes = []
-digest = "951f83b94d7db62978f2ced9fad0adb201a7a61b993476aac468ec26c29c3798"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "cargo"
-path = "https://static.rust-lang.org/dist/cargo-1.93.1-aarch64-apple-darwin.tar.gz"
+path = "https://sdk.vorpal.build/source/cargo-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
 digest = "ad2506123158e906da7e118e4077dfca5995ee120e2693444a3647b7249be808"
@@ -90,7 +50,7 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "clippy"
-path = "https://static.rust-lang.org/dist/clippy-1.93.1-aarch64-apple-darwin.tar.gz"
+path = "https://sdk.vorpal.build/source/clippy-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
 digest = "098f2d1d808bc417bfa1dc63419ffedb1781ca65dd780858c0f8f67e9decb57b"
@@ -98,39 +58,15 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "clippy"
-path = "https://static.rust-lang.org/dist/clippy-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
+path = "https://sdk.vorpal.build/source/clippy-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
 includes = []
 excludes = []
 digest = "4c20fc23ed2870442608ced8a9e9c314a4b27fe78fed356e0092efd377c44681"
 platform = "aarch64-linux"
 
 [[sources]]
-name = "clippy"
-path = "https://static.rust-lang.org/dist/clippy-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
-includes = []
-excludes = []
-digest = "a5515f5ede4c8c2c751647e710747a021e22df00d6c80778628cded51d24ec70"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "clippy"
-path = "https://static.rust-lang.org/dist/clippy-1.93.1-x86_64-apple-darwin.tar.gz"
-includes = []
-excludes = []
-digest = "ccaa3b8977abdc174d1fa28c6cbcbf81848b2b53885ff1f16915d7e47de76087"
-platform = "x86_64-darwin"
-
-[[sources]]
 name = "coreutils"
-path = "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-9.7.tar.gz"
-includes = []
-excludes = []
-digest = "a7abdad032ae6c318dbb4c9b444d9031ab34d1308700005c4bd5eb5156cad523"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "coreutils"
-path = "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-9.7.tar.gz"
+path = "https://sdk.vorpal.build/source/coreutils-9.7.tar.gz"
 includes = []
 excludes = []
 digest = "a7abdad032ae6c318dbb4c9b444d9031ab34d1308700005c4bd5eb5156cad523"
@@ -138,47 +74,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "crane"
-path = "https://github.com/google/go-containerregistry/archive/refs/tags/v0.21.1.tar.gz"
+path = "https://sdk.vorpal.build/source/crane-v0.21.1.tar.gz"
 includes = []
 excludes = []
 digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "crane"
-path = "https://github.com/google/go-containerregistry/archive/refs/tags/v0.21.1.tar.gz"
-includes = []
-excludes = []
-digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "crane"
-path = "https://github.com/google/go-containerregistry/archive/refs/tags/v0.21.1.tar.gz"
-includes = []
-excludes = []
-digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "crane"
-path = "https://github.com/google/go-containerregistry/archive/refs/tags/v0.21.1.tar.gz"
-includes = []
-excludes = []
-digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
-platform = "aarch64-linux"
-
-[[sources]]
 name = "curl"
-path = "https://curl.se/download/curl-8.15.0.tar.xz"
-includes = []
-excludes = []
-digest = "565e83672abb0ba470bbfcb07f49877b54abc68a51c4dd7831c61129fed9e244"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "curl"
-path = "https://curl.se/download/curl-8.15.0.tar.xz"
+path = "https://sdk.vorpal.build/source/curl-8.15.0.tar.xz"
 includes = []
 excludes = []
 digest = "565e83672abb0ba470bbfcb07f49877b54abc68a51c4dd7831c61129fed9e244"
@@ -186,15 +90,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "curl-cacert"
-path = "https://curl.se/ca/cacert.pem"
-includes = []
-excludes = []
-digest = "2f4bfe5eb47cf2325d70469a0488a20d0b451d622c5b4bbf02935c5661d9de36"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "curl-cacert"
-path = "https://curl.se/ca/cacert.pem"
+path = "https://sdk.vorpal.build/source/cacert-1776122862.pem"
 includes = []
 excludes = []
 digest = "2f4bfe5eb47cf2325d70469a0488a20d0b451d622c5b4bbf02935c5661d9de36"
@@ -202,15 +98,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "diffutils"
-path = "https://ftpmirror.gnu.org/gnu/diffutils/diffutils-3.12.tar.xz"
-includes = []
-excludes = []
-digest = "7e416707fa95ffddaae20d11541834bad8d6df24b6bcc8044c2f16a7fb27755e"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "diffutils"
-path = "https://ftpmirror.gnu.org/gnu/diffutils/diffutils-3.12.tar.xz"
+path = "https://sdk.vorpal.build/source/diffutils-3.12.tar.xz"
 includes = []
 excludes = []
 digest = "7e416707fa95ffddaae20d11541834bad8d6df24b6bcc8044c2f16a7fb27755e"
@@ -218,15 +106,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "file"
-path = "https://astron.com/pub/file/file-5.46.tar.gz"
-includes = []
-excludes = []
-digest = "07a8a2f5e1458359d20f420865e4a246c55c1b85176274dfee81e109e9789fb2"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "file"
-path = "https://astron.com/pub/file/file-5.46.tar.gz"
+path = "https://sdk.vorpal.build/source/file-5.46.tar.gz"
 includes = []
 excludes = []
 digest = "07a8a2f5e1458359d20f420865e4a246c55c1b85176274dfee81e109e9789fb2"
@@ -234,15 +114,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "findutils"
-path = "https://ftpmirror.gnu.org/gnu/findutils/findutils-4.10.0.tar.xz"
-includes = []
-excludes = []
-digest = "242f804d87a5036bb0fab99966227dc61e853e5a67e1b10c3cc45681c792657e"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "findutils"
-path = "https://ftpmirror.gnu.org/gnu/findutils/findutils-4.10.0.tar.xz"
+path = "https://sdk.vorpal.build/source/findutils-4.10.0.tar.xz"
 includes = []
 excludes = []
 digest = "242f804d87a5036bb0fab99966227dc61e853e5a67e1b10c3cc45681c792657e"
@@ -250,15 +122,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "gawk"
-path = "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.gz"
-includes = []
-excludes = []
-digest = "33ad80dd59a028d9ac67cffeb9cb35483b268c530bd90d18bb245596d3847103"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "gawk"
-path = "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.gz"
+path = "https://sdk.vorpal.build/source/gawk-5.3.2.tar.gz"
 includes = []
 excludes = []
 digest = "33ad80dd59a028d9ac67cffeb9cb35483b268c530bd90d18bb245596d3847103"
@@ -266,15 +130,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "gcc"
-path = "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-includes = []
-excludes = []
-digest = "cf322f18454e1f54a0ebf661b4c3b556de43651aea8bc7a3bb14ee3863ed56d4"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "gcc"
-path = "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+path = "https://sdk.vorpal.build/source/gcc-15.2.0.tar.xz"
 includes = []
 excludes = []
 digest = "cf322f18454e1f54a0ebf661b4c3b556de43651aea8bc7a3bb14ee3863ed56d4"
@@ -282,63 +138,31 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "gettext"
-path = "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
-includes = []
-excludes = []
-digest = "459265943fcb010124e5056bfff3e9fc95d571f3abef9d022b0af18cbc282b02"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "gettext"
-path = "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
+path = "https://sdk.vorpal.build/source/gettext-0.26.tar.gz"
 includes = []
 excludes = []
 digest = "459265943fcb010124e5056bfff3e9fc95d571f3abef9d022b0af18cbc282b02"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "gh"
+path = "https://sdk.vorpal.build/source/gh_2.87.3_macOS_arm64.zip"
+includes = []
+excludes = []
+digest = "d126f084c14a7f32dccfde5ede0770e5359a09a6413bed914ef5d0ca09f21236"
+platform = "aarch64-darwin"
 
 [[sources]]
 name = "git"
-path = "https://www.kernel.org/pub/software/scm/git/git-2.53.0.tar.gz"
+path = "https://sdk.vorpal.build/source/git-2.53.0.tar.gz"
 includes = []
 excludes = []
 digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "git"
-path = "https://www.kernel.org/pub/software/scm/git/git-2.53.0.tar.gz"
-includes = []
-excludes = []
-digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "git"
-path = "https://www.kernel.org/pub/software/scm/git/git-2.53.0.tar.gz"
-includes = []
-excludes = []
-digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "git"
-path = "https://www.kernel.org/pub/software/scm/git/git-2.53.0.tar.gz"
-includes = []
-excludes = []
-digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
-platform = "aarch64-linux"
-
-[[sources]]
 name = "glibc"
-path = "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.42.tar.gz"
-includes = []
-excludes = []
-digest = "ce551ab3767e6b55726d763a14f98bfc4bff9ebcd3516f478885408e454942b1"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "glibc"
-path = "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.42.tar.gz"
+path = "https://sdk.vorpal.build/source/glibc-2.42.tar.gz"
 includes = []
 excludes = []
 digest = "ce551ab3767e6b55726d763a14f98bfc4bff9ebcd3516f478885408e454942b1"
@@ -346,15 +170,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "glibc-patch"
-path = "https://www.linuxfromscratch.org/patches/lfs/12.4/glibc-2.42-fhs-1.patch"
-includes = []
-excludes = []
-digest = "69cf0653ad0a6a178366d291f30629d4e1cb633178aa4b8efbea0c851fb944ca"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "glibc-patch"
-path = "https://www.linuxfromscratch.org/patches/lfs/12.4/glibc-2.42-fhs-1.patch"
+path = "https://sdk.vorpal.build/source/glibc-2.42-fhs-1.patch"
 includes = []
 excludes = []
 digest = "69cf0653ad0a6a178366d291f30629d4e1cb633178aa4b8efbea0c851fb944ca"
@@ -362,15 +178,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "gmp"
-path = "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.gz"
-includes = []
-excludes = []
-digest = "191226cef6e9ce60e291e178db47682aadea28cb3e92f35f006ba317f3e10195"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "gmp"
-path = "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.gz"
+path = "https://sdk.vorpal.build/source/gmp-6.3.0.tar.gz"
 includes = []
 excludes = []
 digest = "191226cef6e9ce60e291e178db47682aadea28cb3e92f35f006ba317f3e10195"
@@ -378,71 +186,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "go"
-path = "https://go.dev/dl/go1.26.0.darwin-amd64.tar.gz"
-includes = []
-excludes = []
-digest = "73226b2c27fc779b8e9432dd8a9db76d6baebe3fb123c76028e20bf3ace33808"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "go"
-path = "https://go.dev/dl/go1.26.0.darwin-arm64.tar.gz"
+path = "https://sdk.vorpal.build/source/go1.26.0.darwin-arm64.tar.gz"
 includes = []
 excludes = []
 digest = "83d3ebad7958766647de4d3a8a1b2d3860da607632ac07889085b933e3e97f0f"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "go"
-path = "https://go.dev/dl/go1.26.0.linux-arm64.tar.gz"
-includes = []
-excludes = []
-digest = "bcee4e23358013d48b6ad5eb2152dc64dc320d7a6dfac8ed56767f2243b0213a"
-platform = "aarch64-linux"
-
-[[sources]]
-name = "go"
-path = "https://go.dev/dl/go1.26.0.linux-amd64.tar.gz"
-includes = []
-excludes = []
-digest = "d23a8bd1d7050453d53bcb13271e7682a176463a6f53992b1a2cedf17310ef30"
-platform = "x86_64-linux"
-
-[[sources]]
 name = "goimports"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
-includes = []
-excludes = []
-digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "aarch64-darwin"
-
-[[sources]]
-name = "goimports"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
-includes = []
-excludes = []
-digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "goimports"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
-includes = []
-excludes = []
-digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "goimports"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
-includes = []
-excludes = []
-digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "aarch64-linux"
-
-[[sources]]
-name = "gopls"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
 includes = []
 excludes = []
 digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
@@ -450,39 +202,15 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "gopls"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
 includes = []
 excludes = []
 digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "gopls"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
-includes = []
-excludes = []
-digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "gopls"
-path = "https://go.googlesource.com/tools/+archive/refs/tags/v0.42.0.tar.gz"
-includes = []
-excludes = []
-digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "aarch64-linux"
+platform = "aarch64-darwin"
 
 [[sources]]
 name = "grep"
-path = "https://ftpmirror.gnu.org/gnu/grep/grep-3.12.tar.gz"
-includes = []
-excludes = []
-digest = "127096050676822f1f9f18e2bdf847f74907ec691562959cdcbf07e7d524012c"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "grep"
-path = "https://ftpmirror.gnu.org/gnu/grep/grep-3.12.tar.gz"
+path = "https://sdk.vorpal.build/source/grep-3.12.tar.gz"
 includes = []
 excludes = []
 digest = "127096050676822f1f9f18e2bdf847f74907ec691562959cdcbf07e7d524012c"
@@ -490,47 +218,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "grpcurl"
-path = "https://github.com/fullstorydev/grpcurl/archive/refs/tags/v1.9.3.tar.gz"
+path = "https://sdk.vorpal.build/source/grpcurl-v1.9.3.tar.gz"
 includes = []
 excludes = []
 digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "grpcurl"
-path = "https://github.com/fullstorydev/grpcurl/archive/refs/tags/v1.9.3.tar.gz"
-includes = []
-excludes = []
-digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "grpcurl"
-path = "https://github.com/fullstorydev/grpcurl/archive/refs/tags/v1.9.3.tar.gz"
-includes = []
-excludes = []
-digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "grpcurl"
-path = "https://github.com/fullstorydev/grpcurl/archive/refs/tags/v1.9.3.tar.gz"
-includes = []
-excludes = []
-digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
-platform = "aarch64-linux"
-
-[[sources]]
 name = "gzip"
-path = "https://ftpmirror.gnu.org/gnu/gzip/gzip-1.14.tar.gz"
-includes = []
-excludes = []
-digest = "82c708cb0f1ae98c1bcd38edb744ece2cc13cbbd65379a11ff030f86a140ce3d"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "gzip"
-path = "https://ftpmirror.gnu.org/gnu/gzip/gzip-1.14.tar.gz"
+path = "https://sdk.vorpal.build/source/gzip-1.14.tar.gz"
 includes = []
 excludes = []
 digest = "82c708cb0f1ae98c1bcd38edb744ece2cc13cbbd65379a11ff030f86a140ce3d"
@@ -538,15 +234,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "libidn2"
-path = "https://ftpmirror.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
-includes = []
-excludes = []
-digest = "a5a46eb63af153ca526f17133b2f5be09bc434b7cdc25f924a2580b879ab9b9c"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "libidn2"
-path = "https://ftpmirror.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+path = "https://sdk.vorpal.build/source/libidn2-2.3.8.tar.gz"
 includes = []
 excludes = []
 digest = "a5a46eb63af153ca526f17133b2f5be09bc434b7cdc25f924a2580b879ab9b9c"
@@ -554,15 +242,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "libpsl"
-path = "https://github.com/rockdaboot/libpsl/releases/download/0.21.5/libpsl-0.21.5.tar.gz"
-includes = []
-excludes = []
-digest = "65ecfe61646c50119a018a2003149833c11387efd92462f974f1ff9f907c1d78"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "libpsl"
-path = "https://github.com/rockdaboot/libpsl/releases/download/0.21.5/libpsl-0.21.5.tar.gz"
+path = "https://sdk.vorpal.build/source/libpsl-0.21.5.tar.gz"
 includes = []
 excludes = []
 digest = "65ecfe61646c50119a018a2003149833c11387efd92462f974f1ff9f907c1d78"
@@ -570,15 +250,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "libunistring"
-path = "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
-includes = []
-excludes = []
-digest = "e9d4afe75ff42ffce5e55c7267a45d2b6a2c3909d8d8e1ba09cdb99f28896b4d"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "libunistring"
-path = "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
+path = "https://sdk.vorpal.build/source/libunistring-1.3.tar.gz"
 includes = []
 excludes = []
 digest = "e9d4afe75ff42ffce5e55c7267a45d2b6a2c3909d8d8e1ba09cdb99f28896b4d"
@@ -586,15 +258,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "linux"
-path = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.16.1.tar.xz"
-includes = []
-excludes = []
-digest = "40d7204e3d3f1112f0fb32d32cd18421db103a8564c7b277c2b83d54df5b2ff2"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "linux"
-path = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.16.1.tar.xz"
+path = "https://sdk.vorpal.build/source/linux-6.16.1.tar.xz"
 includes = []
 excludes = []
 digest = "40d7204e3d3f1112f0fb32d32cd18421db103a8564c7b277c2b83d54df5b2ff2"
@@ -602,15 +266,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "m4"
-path = "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.20.tar.gz"
-includes = []
-excludes = []
-digest = "633adb94257b39e0e3f9785ea7ccad7ce9b31b22914fdacdcc5accf2b09fba16"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "m4"
-path = "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.20.tar.gz"
+path = "https://sdk.vorpal.build/source/m4-1.4.20.tar.gz"
 includes = []
 excludes = []
 digest = "633adb94257b39e0e3f9785ea7ccad7ce9b31b22914fdacdcc5accf2b09fba16"
@@ -618,15 +274,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "make"
-path = "https://ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.gz"
-includes = []
-excludes = []
-digest = "8dfe7b0e51b3e190cd75e046880855ac1be76cf36961e5cfcc82bfa91b2c3ba8"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "make"
-path = "https://ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.gz"
+path = "https://sdk.vorpal.build/source/make-4.4.1.tar.gz"
 includes = []
 excludes = []
 digest = "8dfe7b0e51b3e190cd75e046880855ac1be76cf36961e5cfcc82bfa91b2c3ba8"
@@ -634,15 +282,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "mpc"
-path = "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
-includes = []
-excludes = []
-digest = "c179fbcd6e48931a16c0af37d0c4a5e1688dd07d71e2b4a532c68cd5edbb5b72"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "mpc"
-path = "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+path = "https://sdk.vorpal.build/source/mpc-1.3.1.tar.gz"
 includes = []
 excludes = []
 digest = "c179fbcd6e48931a16c0af37d0c4a5e1688dd07d71e2b4a532c68cd5edbb5b72"
@@ -650,15 +290,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "mpfr"
-path = "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
-includes = []
-excludes = []
-digest = "837f1bf914eb615761136e6bcd2d49502865b18c0f0d18b4decb513355c4449b"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "mpfr"
-path = "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
+path = "https://sdk.vorpal.build/source/mpfr-4.2.2.tar.xz"
 includes = []
 excludes = []
 digest = "837f1bf914eb615761136e6bcd2d49502865b18c0f0d18b4decb513355c4449b"
@@ -666,15 +298,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "ncurses"
-path = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250809.tgz"
-includes = []
-excludes = []
-digest = "e67077219f4e56cc6cc56958104a9271871ef65ef7985081aced1fd5024f9f47"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "ncurses"
-path = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250809.tgz"
+path = "https://sdk.vorpal.build/source/ncurses-6.5-20250809.tar.gz"
 includes = []
 excludes = []
 digest = "e67077219f4e56cc6cc56958104a9271871ef65ef7985081aced1fd5024f9f47"
@@ -682,47 +306,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "nodejs"
-path = "https://nodejs.org/dist/v22.22.0/node-v22.22.0-linux-arm64.tar.gz"
-includes = []
-excludes = []
-digest = "34c6e1d1b1d2da8e90f2a3480f1d3e57a73c80900a27fccfac9e15f1a44809be"
-platform = "aarch64-linux"
-
-[[sources]]
-name = "nodejs"
-path = "https://nodejs.org/dist/v22.22.0/node-v22.22.0-darwin-arm64.tar.gz"
+path = "https://sdk.vorpal.build/source/node-v22.22.0-darwin-arm64.tar.gz"
 includes = []
 excludes = []
 digest = "852a244f9da062f7d22326a7bc3d7836745521232bd44b06468ec48e1cf359e4"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "nodejs"
-path = "https://nodejs.org/dist/v22.22.0/node-v22.22.0-linux-x64.tar.gz"
-includes = []
-excludes = []
-digest = "85e8bfadee08751035db748cfe0e6f2cd99cfe4ed854b1ac2fb253ada3f13765"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "nodejs"
-path = "https://nodejs.org/dist/v22.22.0/node-v22.22.0-darwin-x64.tar.gz"
-includes = []
-excludes = []
-digest = "b55ad03b2651ed20e6c8c6ea4bd92c5159a53f93885787bb49dc02ee16ce3e8a"
-platform = "x86_64-darwin"
-
-[[sources]]
 name = "openssl"
-path = "https://www.openssl.org/source/openssl-3.5.2.tar.gz"
-includes = []
-excludes = []
-digest = "c18db5dccbd9ee71d1454dbf275b508c1fa452b133f0e8e9812d6f8135c29362"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "openssl"
-path = "https://www.openssl.org/source/openssl-3.5.2.tar.gz"
+path = "https://sdk.vorpal.build/source/openssl-3.5.2.tar.gz"
 includes = []
 excludes = []
 digest = "c18db5dccbd9ee71d1454dbf275b508c1fa452b133f0e8e9812d6f8135c29362"
@@ -730,15 +322,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "patch"
-path = "https://ftpmirror.gnu.org/gnu/patch/patch-2.8.tar.gz"
-includes = []
-excludes = []
-digest = "a003cf376248ecf2dc3edbce55f672f7677ff95ef94dd7ce6fdcef8353ecde7c"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "patch"
-path = "https://ftpmirror.gnu.org/gnu/patch/patch-2.8.tar.gz"
+path = "https://sdk.vorpal.build/source/patch-2.8.tar.gz"
 includes = []
 excludes = []
 digest = "a003cf376248ecf2dc3edbce55f672f7677ff95ef94dd7ce6fdcef8353ecde7c"
@@ -746,15 +330,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "perl"
-path = "https://www.cpan.org/src/5.0/perl-5.42.0.tar.xz"
-includes = []
-excludes = []
-digest = "43a6f8cf15fcedeb66e95c4957ec8bc43db40515de89483e507c01c255fce853"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "perl"
-path = "https://www.cpan.org/src/5.0/perl-5.42.0.tar.xz"
+path = "https://sdk.vorpal.build/source/perl-5.42.0.tar.xz"
 includes = []
 excludes = []
 digest = "43a6f8cf15fcedeb66e95c4957ec8bc43db40515de89483e507c01c255fce853"
@@ -762,55 +338,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "pnpm"
-path = "https://github.com/pnpm/pnpm/releases/download/v10.30.3/pnpm-macos-arm64"
+path = "https://sdk.vorpal.build/source/pnpm-10.30.3-macos-arm64"
 includes = []
 excludes = []
 digest = "29fb1b19aa2ab6c9b310987a836681e34a66f6d05cb583a1e6474cd036b6f4cc"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "pnpm"
-path = "https://github.com/pnpm/pnpm/releases/download/v10.30.3/pnpm-macos-x64"
-includes = []
-excludes = []
-digest = "4a93fe91b5059a9100998b3471dde4918c8a9c6d039662e293061ae0ed2d51af"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "pnpm"
-path = "https://github.com/pnpm/pnpm/releases/download/v10.30.3/pnpm-linux-x64"
-includes = []
-excludes = []
-digest = "8c460b3846f657c7833bc8a42c1ae30c48ef81f1d80adeb41139c7204b4ea129"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "pnpm"
-path = "https://github.com/pnpm/pnpm/releases/download/v10.30.3/pnpm-linux-arm64"
-includes = []
-excludes = []
-digest = "9f21233c7a93c57224f3fdadc52a5f581fae63eacf2a2a521bc4e8495f3e3630"
-platform = "aarch64-linux"
-
-[[sources]]
 name = "protoc"
-path = "https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protoc-34.0-osx-x86_64.zip"
-includes = []
-excludes = []
-digest = "337d9687929aaccd10b82bd7103f7dfa57080f312d8c249ce27c7a0db0ab81b0"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "protoc"
-path = "https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protoc-34.0-linux-x86_64.zip"
-includes = []
-excludes = []
-digest = "72ef7563c9bc34409ec1bbc2632479a47a1c99e458346fcb7f4e1ca0c2f4f008"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "protoc"
-path = "https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protoc-34.0-linux-aarch_64.zip"
+path = "https://sdk.vorpal.build/source/protoc-34.0-linux-aarch_64.zip"
 includes = []
 excludes = []
 digest = "7c9aae2782708d82aee85e682d364a8cc11f352d55b5fe8ccfc8a6f3ab950d30"
@@ -818,7 +354,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "protoc"
-path = "https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protoc-34.0-osx-aarch_64.zip"
+path = "https://sdk.vorpal.build/source/protoc-34.0-osx-aarch_64.zip"
 includes = []
 excludes = []
 digest = "f45e1434669e1f88fd6f7ebf750388ef3135f5477fd7e34d7531e3c18f4751f3"
@@ -826,79 +362,23 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "protoc-gen-go"
-path = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.36.11/protoc-gen-go.v1.36.11.darwin.arm64.tar.gz"
+path = "https://sdk.vorpal.build/source/protoc-gen-go.v1.36.11.darwin.arm64.tar.gz"
 includes = []
 excludes = []
 digest = "33e98fb84e72b46f47f06f3452dad81c2804ae6d32a0045862818332a4c2a0cd"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "protoc-gen-go"
-path = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.36.11/protoc-gen-go.v1.36.11.linux.amd64.tar.gz"
-includes = []
-excludes = []
-digest = "72d35ffffc54b7024a90a0ca8ad2dde80f08822918ba8c52b2d3c0698f5d2d3a"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "protoc-gen-go"
-path = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.36.11/protoc-gen-go.v1.36.11.darwin.amd64.tar.gz"
-includes = []
-excludes = []
-digest = "853fdd384cea7d946dd387167b3b2fe4c5a8b45d7f05425c81fdbc68a2962a21"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "protoc-gen-go"
-path = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.36.11/protoc-gen-go.v1.36.11.linux.arm64.tar.gz"
-includes = []
-excludes = []
-digest = "efac8a58051b6bab6730bb1df2555bcd4088cb4b5f3261c995d65715a1bdfa1e"
-platform = "aarch64-linux"
-
-[[sources]]
 name = "protoc-gen-go-grpc"
-path = "https://github.com/grpc/grpc-go/archive/refs/tags/v1.79.1.tar.gz"
+path = "https://sdk.vorpal.build/source/protoc-gen-go-grpc-v1.79.1.tar.gz"
 includes = []
 excludes = []
 digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "protoc-gen-go-grpc"
-path = "https://github.com/grpc/grpc-go/archive/refs/tags/v1.79.1.tar.gz"
-includes = []
-excludes = []
-digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "protoc-gen-go-grpc"
-path = "https://github.com/grpc/grpc-go/archive/refs/tags/v1.79.1.tar.gz"
-includes = []
-excludes = []
-digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "protoc-gen-go-grpc"
-path = "https://github.com/grpc/grpc-go/archive/refs/tags/v1.79.1.tar.gz"
-includes = []
-excludes = []
-digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
-platform = "aarch64-linux"
-
-[[sources]]
 name = "python"
-path = "https://www.python.org/ftp/python/3.13.7/Python-3.13.7.tar.xz"
-includes = []
-excludes = []
-digest = "2118e11e9ee7b73a88e2fb7c9122455c314660de29beb4d4f15af2d21e15ec42"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "python"
-path = "https://www.python.org/ftp/python/3.13.7/Python-3.13.7.tar.xz"
+path = "https://sdk.vorpal.build/source/Python-3.13.7.tar.xz"
 includes = []
 excludes = []
 digest = "2118e11e9ee7b73a88e2fb7c9122455c314660de29beb4d4f15af2d21e15ec42"
@@ -906,23 +386,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "rsync"
-path = "https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz"
+path = "https://sdk.vorpal.build/source/rsync-3.4.1.tar.gz"
 includes = []
 excludes = []
 digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "rsync"
-path = "https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz"
-includes = []
-excludes = []
-digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
-platform = "aarch64-linux"
+platform = "aarch64-darwin"
 
 [[sources]]
 name = "rust-analyzer"
-path = "https://static.rust-lang.org/dist/rust-analyzer-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
+path = "https://sdk.vorpal.build/source/rust-analyzer-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
 includes = []
 excludes = []
 digest = "5223513027a92ae11735b44130ac325b97ec0a0192dcf39c6a2c153fa888e05b"
@@ -930,31 +402,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "rust-analyzer"
-path = "https://static.rust-lang.org/dist/rust-analyzer-1.93.1-aarch64-apple-darwin.tar.gz"
+path = "https://sdk.vorpal.build/source/rust-analyzer-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
 digest = "5389db13945d33e320e4ddb44c558fda83923ceeac0d9931d6deae8ec2373bd6"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "rust-analyzer"
-path = "https://static.rust-lang.org/dist/rust-analyzer-1.93.1-x86_64-apple-darwin.tar.gz"
-includes = []
-excludes = []
-digest = "58a5c8bb5a20021e546153e23211e806b9918ac147d1dfd0aa64688290dd3449"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "rust-analyzer"
-path = "https://static.rust-lang.org/dist/rust-analyzer-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
-includes = []
-excludes = []
-digest = "edac8e06763f599243d084d763d28ebc0fc4e2022b2bc235645c8e490b3044ca"
-platform = "x86_64-linux"
-
-[[sources]]
 name = "rust-src"
-path = "https://static.rust-lang.org/dist/rust-src-1.93.1.tar.gz"
+path = "https://sdk.vorpal.build/source/rust-src-1.93.1.tar.gz"
 includes = []
 excludes = []
 digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
@@ -962,23 +418,7 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "rust-src"
-path = "https://static.rust-lang.org/dist/rust-src-1.93.1.tar.gz"
-includes = []
-excludes = []
-digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "rust-src"
-path = "https://static.rust-lang.org/dist/rust-src-1.93.1.tar.gz"
-includes = []
-excludes = []
-digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "rust-src"
-path = "https://static.rust-lang.org/dist/rust-src-1.93.1.tar.gz"
+path = "https://sdk.vorpal.build/source/rust-src-1.93.1.tar.gz"
 includes = []
 excludes = []
 digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
@@ -986,7 +426,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "rust-std"
-path = "https://static.rust-lang.org/dist/rust-std-1.93.1-aarch64-apple-darwin.tar.gz"
+path = "https://sdk.vorpal.build/source/rust-std-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
 digest = "0db6b692d4782e80abd92bd18a1f0797229472c62f40417cdc975fb8f3413ee3"
@@ -994,31 +434,15 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "rust-std"
-path = "https://static.rust-lang.org/dist/rust-std-1.93.1-x86_64-apple-darwin.tar.gz"
-includes = []
-excludes = []
-digest = "3aed444a8a36a07a4b6eada82981d10fceb8d89b9cfc7d49dfc0df0cf95f178a"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "rust-std"
-path = "https://static.rust-lang.org/dist/rust-std-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
+path = "https://sdk.vorpal.build/source/rust-std-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
 includes = []
 excludes = []
 digest = "a1f91e63d9d4183645c49505752051c052b9b59a0a949de04673132bdcd85345"
 platform = "aarch64-linux"
 
 [[sources]]
-name = "rust-std"
-path = "https://static.rust-lang.org/dist/rust-std-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
-includes = []
-excludes = []
-digest = "d2a48d1e65027c3382c76850179f85ac03c25f318adbf2a97f5b02271bb1eacf"
-platform = "x86_64-linux"
-
-[[sources]]
 name = "rustc"
-path = "https://static.rust-lang.org/dist/rustc-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
+path = "https://sdk.vorpal.build/source/rustc-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
 includes = []
 excludes = []
 digest = "02c90dcbfd3609d669f037e58b2197b73e67519712cebd016bf38e146df41db1"
@@ -1026,39 +450,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "rustc"
-path = "https://static.rust-lang.org/dist/rustc-1.93.1-aarch64-apple-darwin.tar.gz"
+path = "https://sdk.vorpal.build/source/rustc-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
 digest = "53c9d5b83e6f2c6b826d29043e36c104a179cc8eeb354424d1799632ec82bd3a"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "rustc"
-path = "https://static.rust-lang.org/dist/rustc-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
-includes = []
-excludes = []
-digest = "6ff1c992044553d46afbcb9bf352ceb64a82c9d454bbba78eaf555e7d24bc685"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "rustc"
-path = "https://static.rust-lang.org/dist/rustc-1.93.1-x86_64-apple-darwin.tar.gz"
-includes = []
-excludes = []
-digest = "9c776eef2f1d76a8ed6c4245e246700c5cd724f96181fb58edb23a172d460bcb"
-platform = "x86_64-darwin"
-
-[[sources]]
 name = "rustfmt"
-path = "https://static.rust-lang.org/dist/rustfmt-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
-includes = []
-excludes = []
-digest = "0c45566683fa70ae7dad317a2d9ef510a16a012cb4240dbd12a69e36ed543fab"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "rustfmt"
-path = "https://static.rust-lang.org/dist/rustfmt-1.93.1-aarch64-apple-darwin.tar.gz"
+path = "https://sdk.vorpal.build/source/rustfmt-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
 digest = "17b27bfbf46861bc587e5dc0e04fbc32cbd02f9b111867ffc79653261de7796a"
@@ -1066,15 +466,7 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "rustfmt"
-path = "https://static.rust-lang.org/dist/rustfmt-1.93.1-x86_64-apple-darwin.tar.gz"
-includes = []
-excludes = []
-digest = "5e57b9561d9990473dd6713e9b3191da3bb2c4ff0f28e4b03e15f552812f437f"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "rustfmt"
-path = "https://static.rust-lang.org/dist/rustfmt-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
+path = "https://sdk.vorpal.build/source/rustfmt-1.93.1-aarch64-unknown-linux-gnu.tar.gz"
 includes = []
 excludes = []
 digest = "7df0c4d99214e09a0826f9d4cd6259341be8cb324dd5c3d78103705374b76e6c"
@@ -1082,15 +474,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "sed"
-path = "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.gz"
-includes = []
-excludes = []
-digest = "434ff552af89340088e0d8cb206c251761297909bbee401176bc8f655e8e7cf2"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "sed"
-path = "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.gz"
+path = "https://sdk.vorpal.build/source/sed-4.9.tar.gz"
 includes = []
 excludes = []
 digest = "434ff552af89340088e0d8cb206c251761297909bbee401176bc8f655e8e7cf2"
@@ -1098,47 +482,15 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "staticcheck"
-path = "https://github.com/dominikh/go-tools/archive/refs/tags/2026.1.tar.gz"
+path = "https://sdk.vorpal.build/source/staticcheck-2026.1.tar.gz"
 includes = []
 excludes = []
 digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
 platform = "aarch64-darwin"
 
 [[sources]]
-name = "staticcheck"
-path = "https://github.com/dominikh/go-tools/archive/refs/tags/2026.1.tar.gz"
-includes = []
-excludes = []
-digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
-platform = "x86_64-darwin"
-
-[[sources]]
-name = "staticcheck"
-path = "https://github.com/dominikh/go-tools/archive/refs/tags/2026.1.tar.gz"
-includes = []
-excludes = []
-digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "staticcheck"
-path = "https://github.com/dominikh/go-tools/archive/refs/tags/2026.1.tar.gz"
-includes = []
-excludes = []
-digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
-platform = "aarch64-linux"
-
-[[sources]]
 name = "tar"
-path = "https://ftpmirror.gnu.org/gnu/tar/tar-1.35.tar.gz"
-includes = []
-excludes = []
-digest = "f9bb5f39ed45b1c6a324470515d2ef73e74422c5f345503106d861576d3f02f3"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "tar"
-path = "https://ftpmirror.gnu.org/gnu/tar/tar-1.35.tar.gz"
+path = "https://sdk.vorpal.build/source/tar-1.35.tar.gz"
 includes = []
 excludes = []
 digest = "f9bb5f39ed45b1c6a324470515d2ef73e74422c5f345503106d861576d3f02f3"
@@ -1146,15 +498,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "texinfo"
-path = "https://ftpmirror.gnu.org/gnu/texinfo/texinfo-7.2.tar.gz"
-includes = []
-excludes = []
-digest = "6bc4aa1be570367196b2488d4783f02dae702822db9d2aa9e5d650339e0f770e"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "texinfo"
-path = "https://ftpmirror.gnu.org/gnu/texinfo/texinfo-7.2.tar.gz"
+path = "https://sdk.vorpal.build/source/texinfo-7.2.tar.gz"
 includes = []
 excludes = []
 digest = "6bc4aa1be570367196b2488d4783f02dae702822db9d2aa9e5d650339e0f770e"
@@ -1162,15 +506,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "unzip"
-path = "https://cytranet-dal.dl.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz?viasf=1"
-includes = []
-excludes = []
-digest = "4585067be297ae977da3f81587fcf0a141a8d6ceb6137d199255683ed189c3ed"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "unzip"
-path = "https://cytranet-dal.dl.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz?viasf=1"
+path = "https://sdk.vorpal.build/source/unzip60.tar.gz"
 includes = []
 excludes = []
 digest = "4585067be297ae977da3f81587fcf0a141a8d6ceb6137d199255683ed189c3ed"
@@ -1178,15 +514,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "unzip-patch-fixes"
-path = "https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-6.0-consolidated_fixes-1.patch"
-includes = []
-excludes = []
-digest = "11350935be5bbb743f1a97ec069b78fc2904f92b24abbc7fb3d7f0ff8bb889ea"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "unzip-patch-fixes"
-path = "https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-6.0-consolidated_fixes-1.patch"
+path = "https://sdk.vorpal.build/source/unzip-6.0-consolidated_fixes-1.patch"
 includes = []
 excludes = []
 digest = "11350935be5bbb743f1a97ec069b78fc2904f92b24abbc7fb3d7f0ff8bb889ea"
@@ -1194,15 +522,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "unzip-patch-gcc14"
-path = "https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-6.0-gcc14-1.patch"
-includes = []
-excludes = []
-digest = "d6ac941672086ea4c8d5047d550b40047825a685cc7c48626d2f0939e1a0c797"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "unzip-patch-gcc14"
-path = "https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-6.0-gcc14-1.patch"
+path = "https://sdk.vorpal.build/source/unzip-6.0-gcc14-1.patch"
 includes = []
 excludes = []
 digest = "d6ac941672086ea4c8d5047d550b40047825a685cc7c48626d2f0939e1a0c797"
@@ -1210,15 +530,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "util-linux"
-path = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.1.tar.xz"
-includes = []
-excludes = []
-digest = "1f10bfbd4ac7b3e8058fe837b0ed9274d2b3f603dc2d7cbc3d325dc612b06aaa"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "util-linux"
-path = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.1.tar.xz"
+path = "https://sdk.vorpal.build/source/util-linux-2.41.1.tar.xz"
 includes = []
 excludes = []
 digest = "1f10bfbd4ac7b3e8058fe837b0ed9274d2b3f603dc2d7cbc3d325dc612b06aaa"
@@ -1226,15 +538,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "xz"
-path = "https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1.tar.xz"
-includes = []
-excludes = []
-digest = "24827cfbd8504ed6499a08262caf7d4c4584a5ee2505843526f0f020daf9ab93"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "xz"
-path = "https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1.tar.xz"
+path = "https://sdk.vorpal.build/source/xz-5.8.1.tar.xz"
 includes = []
 excludes = []
 digest = "24827cfbd8504ed6499a08262caf7d4c4584a5ee2505843526f0f020daf9ab93"
@@ -1242,15 +546,7 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "zlib"
-path = "https://zlib.net/fossils/zlib-1.3.1.tar.gz"
-includes = []
-excludes = []
-digest = "3f7995d5f103719283f509c23624287ce95c349439e881ed935a3c2c807bb683"
-platform = "x86_64-linux"
-
-[[sources]]
-name = "zlib"
-path = "https://zlib.net/fossils/zlib-1.3.1.tar.gz"
+path = "https://sdk.vorpal.build/source/zlib-1.3.1.tar.gz"
 includes = []
 excludes = []
 digest = "3f7995d5f103719283f509c23624287ce95c349439e881ed935a3c2c807bb683"

--- a/Vorpal.lock
+++ b/Vorpal.lock
@@ -50,6 +50,14 @@ platform = "x86_64-linux"
 
 [[sources]]
 name = "bun"
+path = "https://sdk.vorpal.build/source/bun-1.3.10-darwin-x64.zip"
+includes = []
+excludes = []
+digest = "53e2e70a6f7ea40998750118e72c9d6581376aabec301e244eb7bb844b4fe5c0"
+platform = "x86_64-darwin"
+
+[[sources]]
+name = "bun"
 path = "https://sdk.vorpal.build/source/bun-1.3.10-linux-aarch64.zip"
 includes = []
 excludes = []
@@ -90,6 +98,14 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "cargo"
+path = "https://sdk.vorpal.build/source/cargo-1.93.1-x86_64-apple-darwin.tar.gz"
+includes = []
+excludes = []
+digest = "951f83b94d7db62978f2ced9fad0adb201a7a61b993476aac468ec26c29c3798"
+platform = "x86_64-darwin"
+
+[[sources]]
+name = "cargo"
 path = "https://sdk.vorpal.build/source/cargo-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
@@ -121,6 +137,14 @@ digest = "a5515f5ede4c8c2c751647e710747a021e22df00d6c80778628cded51d24ec70"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "clippy"
+path = "https://sdk.vorpal.build/source/clippy-1.93.1-x86_64-apple-darwin.tar.gz"
+includes = []
+excludes = []
+digest = "ccaa3b8977abdc174d1fa28c6cbcbf81848b2b53885ff1f16915d7e47de76087"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "coreutils"
 path = "https://sdk.vorpal.build/source/coreutils-9.7.tar.gz"
 includes = []
@@ -161,6 +185,14 @@ digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "crane"
+path = "https://sdk.vorpal.build/source/crane-v0.21.1.tar.gz"
+includes = []
+excludes = []
+digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "curl"
 path = "https://sdk.vorpal.build/source/curl-8.15.0.tar.xz"
 includes = []
@@ -287,6 +319,14 @@ includes = []
 excludes = []
 digest = "459265943fcb010124e5056bfff3e9fc95d571f3abef9d022b0af18cbc282b02"
 platform = "x86_64-linux"
+
+[[sources]]
+name = "gh"
+path = "https://sdk.vorpal.build/source/gh_2.87.3_macOS_amd64.zip"
+includes = []
+excludes = []
+digest = "0dede8ed13c07342124b1e2701d4917bea8ccb751d5b5fc88f4839c510d78673"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "gh"
@@ -337,6 +377,14 @@ digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "git"
+path = "https://sdk.vorpal.build/source/git-2.53.0.tar.gz"
+includes = []
+excludes = []
+digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "glibc"
 path = "https://sdk.vorpal.build/source/glibc-2.42.tar.gz"
 includes = []
@@ -383,6 +431,14 @@ includes = []
 excludes = []
 digest = "191226cef6e9ce60e291e178db47682aadea28cb3e92f35f006ba317f3e10195"
 platform = "x86_64-linux"
+
+[[sources]]
+name = "go"
+path = "https://sdk.vorpal.build/source/go1.26.0.darwin-amd64.tar.gz"
+includes = []
+excludes = []
+digest = "73226b2c27fc779b8e9432dd8a9db76d6baebe3fb123c76028e20bf3ace33808"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "go"
@@ -433,6 +489,14 @@ digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "goimports"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
+includes = []
+excludes = []
+digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "gopls"
 path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
 includes = []
@@ -455,6 +519,14 @@ includes = []
 excludes = []
 digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
 platform = "x86_64-linux"
+
+[[sources]]
+name = "gopls"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
+includes = []
+excludes = []
+digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "grep"
@@ -495,6 +567,14 @@ includes = []
 excludes = []
 digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
 platform = "x86_64-linux"
+
+[[sources]]
+name = "grpcurl"
+path = "https://sdk.vorpal.build/source/grpcurl-v1.9.3.tar.gz"
+includes = []
+excludes = []
+digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "gzip"
@@ -681,6 +761,14 @@ digest = "85e8bfadee08751035db748cfe0e6f2cd99cfe4ed854b1ac2fb253ada3f13765"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "nodejs"
+path = "https://sdk.vorpal.build/source/node-v22.22.0-darwin-x64.tar.gz"
+includes = []
+excludes = []
+digest = "b55ad03b2651ed20e6c8c6ea4bd92c5159a53f93885787bb49dc02ee16ce3e8a"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "openssl"
 path = "https://sdk.vorpal.build/source/openssl-3.5.2.tar.gz"
 includes = []
@@ -738,6 +826,14 @@ platform = "aarch64-darwin"
 
 [[sources]]
 name = "pnpm"
+path = "https://sdk.vorpal.build/source/pnpm-10.30.3-macos-x64"
+includes = []
+excludes = []
+digest = "4a93fe91b5059a9100998b3471dde4918c8a9c6d039662e293061ae0ed2d51af"
+platform = "x86_64-darwin"
+
+[[sources]]
+name = "pnpm"
 path = "https://sdk.vorpal.build/source/pnpm-10.30.3-linux-x64"
 includes = []
 excludes = []
@@ -751,6 +847,14 @@ includes = []
 excludes = []
 digest = "9f21233c7a93c57224f3fdadc52a5f581fae63eacf2a2a521bc4e8495f3e3630"
 platform = "aarch64-linux"
+
+[[sources]]
+name = "protoc"
+path = "https://sdk.vorpal.build/source/protoc-34.0-osx-x86_64.zip"
+includes = []
+excludes = []
+digest = "337d9687929aaccd10b82bd7103f7dfa57080f312d8c249ce27c7a0db0ab81b0"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "protoc"
@@ -794,6 +898,14 @@ platform = "x86_64-linux"
 
 [[sources]]
 name = "protoc-gen-go"
+path = "https://sdk.vorpal.build/source/protoc-gen-go.v1.36.11.darwin.amd64.tar.gz"
+includes = []
+excludes = []
+digest = "853fdd384cea7d946dd387167b3b2fe4c5a8b45d7f05425c81fdbc68a2962a21"
+platform = "x86_64-darwin"
+
+[[sources]]
+name = "protoc-gen-go"
 path = "https://sdk.vorpal.build/source/protoc-gen-go.v1.36.11.linux.arm64.tar.gz"
 includes = []
 excludes = []
@@ -825,6 +937,14 @@ digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "protoc-gen-go-grpc"
+path = "https://sdk.vorpal.build/source/protoc-gen-go-grpc-v1.79.1.tar.gz"
+includes = []
+excludes = []
+digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "python"
 path = "https://sdk.vorpal.build/source/Python-3.13.7.tar.xz"
 includes = []
@@ -863,6 +983,14 @@ includes = []
 excludes = []
 digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
 platform = "x86_64-linux"
+
+[[sources]]
+name = "rsync"
+path = "https://sdk.vorpal.build/source/rsync-3.4.1.tar.gz"
+includes = []
+excludes = []
+digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "rust-analyzer"
@@ -879,6 +1007,14 @@ includes = []
 excludes = []
 digest = "5389db13945d33e320e4ddb44c558fda83923ceeac0d9931d6deae8ec2373bd6"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "rust-analyzer"
+path = "https://sdk.vorpal.build/source/rust-analyzer-1.93.1-x86_64-apple-darwin.tar.gz"
+includes = []
+excludes = []
+digest = "58a5c8bb5a20021e546153e23211e806b9918ac147d1dfd0aa64688290dd3449"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "rust-analyzer"
@@ -913,12 +1049,28 @@ digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "rust-src"
+path = "https://sdk.vorpal.build/source/rust-src-1.93.1.tar.gz"
+includes = []
+excludes = []
+digest = "52da4bcd8bd8e2d0ae2635e1503efa8f5838bd18958b983d52336d73896e7172"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "rust-std"
 path = "https://sdk.vorpal.build/source/rust-std-1.93.1-aarch64-apple-darwin.tar.gz"
 includes = []
 excludes = []
 digest = "0db6b692d4782e80abd92bd18a1f0797229472c62f40417cdc975fb8f3413ee3"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "rust-std"
+path = "https://sdk.vorpal.build/source/rust-std-1.93.1-x86_64-apple-darwin.tar.gz"
+includes = []
+excludes = []
+digest = "3aed444a8a36a07a4b6eada82981d10fceb8d89b9cfc7d49dfc0df0cf95f178a"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "rust-std"
@@ -961,6 +1113,14 @@ digest = "6ff1c992044553d46afbcb9bf352ceb64a82c9d454bbba78eaf555e7d24bc685"
 platform = "x86_64-linux"
 
 [[sources]]
+name = "rustc"
+path = "https://sdk.vorpal.build/source/rustc-1.93.1-x86_64-apple-darwin.tar.gz"
+includes = []
+excludes = []
+digest = "9c776eef2f1d76a8ed6c4245e246700c5cd724f96181fb58edb23a172d460bcb"
+platform = "x86_64-darwin"
+
+[[sources]]
 name = "rustfmt"
 path = "https://sdk.vorpal.build/source/rustfmt-1.93.1-x86_64-unknown-linux-gnu.tar.gz"
 includes = []
@@ -975,6 +1135,14 @@ includes = []
 excludes = []
 digest = "17b27bfbf46861bc587e5dc0e04fbc32cbd02f9b111867ffc79653261de7796a"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "rustfmt"
+path = "https://sdk.vorpal.build/source/rustfmt-1.93.1-x86_64-apple-darwin.tar.gz"
+includes = []
+excludes = []
+digest = "5e57b9561d9990473dd6713e9b3191da3bb2c4ff0f28e4b03e15f552812f437f"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "rustfmt"
@@ -1023,6 +1191,14 @@ includes = []
 excludes = []
 digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
 platform = "x86_64-linux"
+
+[[sources]]
+name = "staticcheck"
+path = "https://sdk.vorpal.build/source/staticcheck-2026.1.tar.gz"
+includes = []
+excludes = []
+digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
+platform = "x86_64-darwin"
 
 [[sources]]
 name = "tar"

--- a/Vorpal.lock
+++ b/Vorpal.lock
@@ -26,6 +26,14 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "bun"
+path = "https://sdk.vorpal.build/source/bun-1.3.10-linux-aarch64.zip"
+includes = []
+excludes = []
+digest = "56e59802c5b606ecccd5e4d1a825eaad58b9ad12b71853b35d459bc3dbd0bf25"
+platform = "aarch64-linux"
+
+[[sources]]
+name = "bun"
 path = "https://sdk.vorpal.build/source/bun-1.3.10-darwin-aarch64.zip"
 includes = []
 excludes = []
@@ -79,6 +87,14 @@ includes = []
 excludes = []
 digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "crane"
+path = "https://sdk.vorpal.build/source/crane-v0.21.1.tar.gz"
+includes = []
+excludes = []
+digest = "a140a303bacb264dae453ef3d65bf6a6ab656ca7f32b8d689fe02edbe541a363"
+platform = "aarch64-linux"
 
 [[sources]]
 name = "curl"
@@ -146,6 +162,14 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "gh"
+path = "https://sdk.vorpal.build/source/gh_2.87.3_linux_arm64.tar.gz"
+includes = []
+excludes = []
+digest = "79ca279bcec97f36a5406102030d9ba61e53864ade2916990c18cb05e09448bf"
+platform = "aarch64-linux"
+
+[[sources]]
+name = "gh"
 path = "https://sdk.vorpal.build/source/gh_2.87.3_macOS_arm64.zip"
 includes = []
 excludes = []
@@ -159,6 +183,14 @@ includes = []
 excludes = []
 digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "git"
+path = "https://sdk.vorpal.build/source/git-2.53.0.tar.gz"
+includes = []
+excludes = []
+digest = "4c08acf32a9dd52cb4f64d1835bade4128af51dd85742245987643cde0aeb9b1"
+platform = "aarch64-linux"
 
 [[sources]]
 name = "glibc"
@@ -193,7 +225,31 @@ digest = "83d3ebad7958766647de4d3a8a1b2d3860da607632ac07889085b933e3e97f0f"
 platform = "aarch64-darwin"
 
 [[sources]]
+name = "go"
+path = "https://sdk.vorpal.build/source/go1.26.0.linux-arm64.tar.gz"
+includes = []
+excludes = []
+digest = "bcee4e23358013d48b6ad5eb2152dc64dc320d7a6dfac8ed56767f2243b0213a"
+platform = "aarch64-linux"
+
+[[sources]]
 name = "goimports"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
+includes = []
+excludes = []
+digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
+platform = "aarch64-darwin"
+
+[[sources]]
+name = "goimports"
+path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
+includes = []
+excludes = []
+digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
+platform = "aarch64-linux"
+
+[[sources]]
+name = "gopls"
 path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
 includes = []
 excludes = []
@@ -206,7 +262,7 @@ path = "https://sdk.vorpal.build/source/go-tools-v0.42.0.tar.gz"
 includes = []
 excludes = []
 digest = "411df8f3301010012a491337a4f5fa884fbcc323fe7e9ad75aa470f4bf921c56"
-platform = "aarch64-darwin"
+platform = "aarch64-linux"
 
 [[sources]]
 name = "grep"
@@ -223,6 +279,14 @@ includes = []
 excludes = []
 digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "grpcurl"
+path = "https://sdk.vorpal.build/source/grpcurl-v1.9.3.tar.gz"
+includes = []
+excludes = []
+digest = "3db5cef04f38e71c4007ed96cc827209ae5a1b6613c710cd656a252fafcde86c"
+platform = "aarch64-linux"
 
 [[sources]]
 name = "gzip"
@@ -306,6 +370,14 @@ platform = "aarch64-linux"
 
 [[sources]]
 name = "nodejs"
+path = "https://sdk.vorpal.build/source/node-v22.22.0-linux-arm64.tar.gz"
+includes = []
+excludes = []
+digest = "34c6e1d1b1d2da8e90f2a3480f1d3e57a73c80900a27fccfac9e15f1a44809be"
+platform = "aarch64-linux"
+
+[[sources]]
+name = "nodejs"
 path = "https://sdk.vorpal.build/source/node-v22.22.0-darwin-arm64.tar.gz"
 includes = []
 excludes = []
@@ -345,6 +417,14 @@ digest = "29fb1b19aa2ab6c9b310987a836681e34a66f6d05cb583a1e6474cd036b6f4cc"
 platform = "aarch64-darwin"
 
 [[sources]]
+name = "pnpm"
+path = "https://sdk.vorpal.build/source/pnpm-10.30.3-linux-arm64"
+includes = []
+excludes = []
+digest = "9f21233c7a93c57224f3fdadc52a5f581fae63eacf2a2a521bc4e8495f3e3630"
+platform = "aarch64-linux"
+
+[[sources]]
 name = "protoc"
 path = "https://sdk.vorpal.build/source/protoc-34.0-linux-aarch_64.zip"
 includes = []
@@ -369,12 +449,28 @@ digest = "33e98fb84e72b46f47f06f3452dad81c2804ae6d32a0045862818332a4c2a0cd"
 platform = "aarch64-darwin"
 
 [[sources]]
+name = "protoc-gen-go"
+path = "https://sdk.vorpal.build/source/protoc-gen-go.v1.36.11.linux.arm64.tar.gz"
+includes = []
+excludes = []
+digest = "efac8a58051b6bab6730bb1df2555bcd4088cb4b5f3261c995d65715a1bdfa1e"
+platform = "aarch64-linux"
+
+[[sources]]
 name = "protoc-gen-go-grpc"
 path = "https://sdk.vorpal.build/source/protoc-gen-go-grpc-v1.79.1.tar.gz"
 includes = []
 excludes = []
 digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "protoc-gen-go-grpc"
+path = "https://sdk.vorpal.build/source/protoc-gen-go-grpc-v1.79.1.tar.gz"
+includes = []
+excludes = []
+digest = "f1d541547bc8d5199a9877209b5a65ee26a3e983965ccbf9000785c75c91c0bd"
+platform = "aarch64-linux"
 
 [[sources]]
 name = "python"
@@ -391,6 +487,14 @@ includes = []
 excludes = []
 digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "rsync"
+path = "https://sdk.vorpal.build/source/rsync-3.4.1.tar.gz"
+includes = []
+excludes = []
+digest = "5ca18fad3772ffe2a04feaffd4639482632baa0fc6b357622b51ea9d17658ec0"
+platform = "aarch64-linux"
 
 [[sources]]
 name = "rust-analyzer"
@@ -487,6 +591,14 @@ includes = []
 excludes = []
 digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
 platform = "aarch64-darwin"
+
+[[sources]]
+name = "staticcheck"
+path = "https://sdk.vorpal.build/source/staticcheck-2026.1.tar.gz"
+includes = []
+excludes = []
+digest = "fb3b8a69d94d507016bea39129274c2329704a451c0db6af620bcd8486288241"
+platform = "aarch64-linux"
 
 [[sources]]
 name = "tar"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-cli"
 publish = false
-version = "0.1.0"
+version = "0.1.1"
 
 [[bin]]
 name = "vorpal"

--- a/cli/src/command/template/rust/Cargo.lock
+++ b/cli/src/command/template/rust/Cargo.lock
@@ -101,9 +101,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -150,9 +150,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -587,15 +587,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -849,9 +848,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1141,7 +1140,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1201,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1349,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -1386,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1711,9 +1710,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -2028,9 +2027,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vorpal-sdk"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ad20073079f0b1b295f339f5550d03510eb1e7ebe5f53f7ca10fd714a6d64e"
+checksum = "f278dc8ba6f46b9d58a089511af3e3b3270a488d0d77dd521157f0a65dbb1ecd"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/src/command/template/rust/Cargo.toml
+++ b/cli/src/command/template/rust/Cargo.toml
@@ -14,6 +14,6 @@ path = "src/vorpal.rs"
 [dependencies]
 anyhow = "1"
 tokio = { features = ["rt-multi-thread"], version = "1" }
-vorpal-sdk = { version = "0.1.0" }
+vorpal-sdk = { version = "0.1.1" }
 
 [workspace]

--- a/cli/src/command/template/typescript/bun.lock
+++ b/cli/src/command/template/typescript/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "example",
       "dependencies": {
-        "@altf4llc/vorpal-sdk": "0.1.0",
+        "@altf4llc/vorpal-sdk": "0.1.1",
       },
       "devDependencies": {
         "@types/bun": "1.3.12",
@@ -14,7 +14,7 @@
     },
   },
   "packages": {
-    "@altf4llc/vorpal-sdk": ["@altf4llc/vorpal-sdk@0.1.0", "", { "dependencies": { "@bufbuild/protobuf": "2.11.0", "@grpc/grpc-js": "1.14.3", "smol-toml": "1.6.1" } }, "sha512-wDm1C2qtwi6vHd5jVm/NLf3cK1fAoU7ext//iKniDsSQ2vigISFQfIIjhd+Ly2pswtO8meG1TMl7fpDUk1stcA=="],
+    "@altf4llc/vorpal-sdk": ["@altf4llc/vorpal-sdk@0.1.1", "", { "dependencies": { "@bufbuild/protobuf": "2.11.0", "@grpc/grpc-js": "1.14.3", "smol-toml": "1.6.1" } }, "sha512-RiM2/8/vv79TNAJFrcjMhab7FVCszI/0g9cNsiVZjPFht2CT3DaPEqdXRJqDngwHVH6kUrpp/64/YfmqeBXxvg=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.11.0", "", {}, "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ=="],
 
@@ -46,7 +46,7 @@
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
-    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -72,7 +72,7 @@
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
-    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+    "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -84,7 +84,7 @@
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 

--- a/cli/src/command/template/typescript/package.json
+++ b/cli/src/command/template/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "bun run src/main.ts"
   },
   "dependencies": {
-    "@altf4llc/vorpal-sdk": "0.1.0"
+    "@altf4llc/vorpal-sdk": "0.1.1"
   },
   "devDependencies": {
     "@types/bun": "1.3.12",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-config"
 publish = false
-version = "0.1.0"
+version = "0.1.1"
 
 [[bin]]
 name = "vorpal-config"

--- a/config/src/artifact/vorpal_shell.rs
+++ b/config/src/artifact/vorpal_shell.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use vorpal_sdk::artifact::{
     bun::Bun,
     crane::Crane,
+    gh::Gh,
     go::Go,
     goimports::Goimports,
     gopls::Gopls,
@@ -13,6 +14,7 @@ use vorpal_sdk::artifact::{
     protoc::Protoc,
     protoc_gen_go::ProtocGenGo,
     protoc_gen_go_grpc::ProtocGenGoGrpc,
+    rsync::Rsync,
     staticcheck::Staticcheck,
 };
 use vorpal_sdk::{artifact, context::ConfigContext};
@@ -28,6 +30,7 @@ impl VorpalShell {
     pub async fn build(self, context: &mut ConfigContext) -> Result<String> {
         let bun = Bun::new().build(context).await?;
         let crane = Crane::new().build(context).await?;
+        let gh = Gh::new().build(context).await?;
         let go = Go::new().build(context).await?;
         let goimports = Goimports::new().build(context).await?;
         let gopls = Gopls::new().build(context).await?;
@@ -37,12 +40,14 @@ impl VorpalShell {
         let protoc = Protoc::new().build(context).await?;
         let protoc_gen_go = ProtocGenGo::new().build(context).await?;
         let protoc_gen_go_grpc = ProtocGenGoGrpc::new().build(context).await?;
+        let rsync = Rsync::new().build(context).await?;
         let staticcheck = Staticcheck::new().build(context).await?;
 
         artifact::DevelopmentEnvironment::new("vorpal-shell", SYSTEMS.to_vec())
             .with_artifacts(vec![
                 bun,
                 crane,
+                gh,
                 go,
                 goimports,
                 gopls,
@@ -52,6 +57,7 @@ impl VorpalShell {
                 protoc,
                 protoc_gen_go,
                 protoc_gen_go_grpc,
+                rsync,
                 staticcheck,
             ])
             .with_environments(vec![

--- a/script/install.sh
+++ b/script/install.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Environment variables:
 #   VORPAL_NONINTERACTIVE=1    Enable non-interactive mode
 #   CI=true                    Enable non-interactive mode
-#   VORPAL_VERSION=<ver>       Version to install (default: 0.1.0)
+#   VORPAL_VERSION=<ver>       Version to install (default: 0.1.1)
 #   VORPAL_NO_SERVICE=1        Skip service installation
 #   VORPAL_SERVICES=<list>     Comma-separated services to install (default: agent,registry,worker)
 #   VORPAL_NO_PATH=1           Skip PATH configuration
@@ -23,7 +23,7 @@ set -euo pipefail
 
 # -- Constants ----------------------------------------------------------------
 
-VORPAL_VERSION="${VORPAL_VERSION:-0.1.0}"
+VORPAL_VERSION="${VORPAL_VERSION:-0.1.1}"
 VORPAL_INSTALL_DIR="$HOME/.vorpal"
 VORPAL_SYSTEM_DIR="/var/lib/vorpal"
 VORPAL_REPO="ALT-F4-LLC/vorpal"
@@ -361,7 +361,7 @@ Install Vorpal to ~/.vorpal and configure system services.
 
 Options:
   -y, --yes              Run in non-interactive mode (skip prompts)
-  -v, --version <ver>    Version to install (default: 0.1.0)
+  -v, --version <ver>    Version to install (default: 0.1.1)
       --services <list>  Comma-separated services to install (default: agent,registry,worker)
       --no-service       Skip service installation
       --no-path          Skip PATH configuration
@@ -376,7 +376,7 @@ Options:
 Environment variables:
   VORPAL_NONINTERACTIVE=1    Enable non-interactive mode
   CI=true                    Enable non-interactive mode
-  VORPAL_VERSION=<ver>       Version to install (default: 0.1.0)
+  VORPAL_VERSION=<ver>       Version to install (default: 0.1.1)
   VORPAL_NO_SERVICE=1        Skip service installation
   VORPAL_SERVICES=<list>     Comma-separated services (default: agent,registry,worker)
   VORPAL_NO_PATH=1           Skip PATH configuration
@@ -400,7 +400,7 @@ parse_args() {
                 if [[ $# -lt 2 ]]; then
                     print_error "Missing value for $1" \
                         "The $1 flag requires a version argument." \
-                        "Example: install.sh $1 0.1.0"
+                        "Example: install.sh $1 0.1.1"
                     exit 1
                 fi
                 VORPAL_VERSION="$2"
@@ -725,8 +725,8 @@ resolve_version() {
         http_code="$(curl -sS -o /dev/null -w "%{http_code}" "$api_url" 2>/dev/null)" || true
 
         if [[ "$http_code" = "403" ]]; then
-            print_warning "GitHub API rate limit reached. Falling back to 0.1.0."
-            version="0.1.0"
+            print_warning "GitHub API rate limit reached. Falling back to 0.1.1."
+            version="0.1.1"
         elif [[ "$http_code" = "200" ]]; then
             api_response="$(curl -fsSL "$api_url" 2>/dev/null)" || true
             if [[ -n "$api_response" ]]; then
@@ -736,16 +736,16 @@ resolve_version() {
                 if [[ -n "$tag" ]]; then
                     version="$tag"
                 else
-                    print_warning "Could not parse latest version from GitHub API. Falling back to 0.1.0."
-                    version="0.1.0"
+                    print_warning "Could not parse latest version from GitHub API. Falling back to 0.1.1."
+                    version="0.1.1"
                 fi
             else
-                print_warning "Could not fetch latest version from GitHub API. Falling back to 0.1.0."
-                version="0.1.0"
+                print_warning "Could not fetch latest version from GitHub API. Falling back to 0.1.1."
+                version="0.1.1"
             fi
         else
-            print_warning "GitHub API returned HTTP ${http_code}. Falling back to 0.1.0."
-            version="0.1.0"
+            print_warning "GitHub API returned HTTP ${http_code}. Falling back to 0.1.1."
+            version="0.1.1"
         fi
     fi
 
@@ -762,7 +762,7 @@ resolve_version() {
             "Available channels:
     ${_sym_bullet} nightly -- latest development build (updated daily)
     ${_sym_bullet} latest  -- most recent stable release" \
-            "Or specify an exact tag: --version v0.1.0
+            "Or specify an exact tag: --version v0.1.1
   See all releases: ${VORPAL_GITHUB_URL}/releases"
         exit 1
     fi

--- a/script/source.sh
+++ b/script/source.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+# Vorpal Source Downloader
+# =============================================================================
+# Downloads all source files referenced in Vorpal.lock, organized by platform.
+#
+# Usage: ./script/source.sh
+#
+# Downloads to: ${PWD}/source/<platform>/<filename>
+# =============================================================================
+
+LOCKFILE="${PWD}/Vorpal.lock"
+SOURCE_DIR="${PWD}/source"
+
+if [ ! -f "$LOCKFILE" ]; then
+    echo "Error: Vorpal.lock not found at ${LOCKFILE}" >&2
+    exit 1
+fi
+
+# Parse Vorpal.lock to extract (platform, url) pairs.
+# Reads path and platform fields from each [[sources]] entry.
+# Output: one "platform url" pair per line, deduplicated.
+parse_sources() {
+    awk '
+        /^\[\[sources\]\]/ { url=""; plat="" }
+        /^path = "/ { url=$0; sub(/^path = "/, "", url); sub(/"$/, "", url) }
+        /^platform = "/ { plat=$0; sub(/^platform = "/, "", plat); sub(/"$/, "", plat) }
+        length(url) > 0 && length(plat) > 0 { print plat " " url; url=""; plat="" }
+    ' "$LOCKFILE" | sort -u
+}
+
+pairs=$(parse_sources)
+
+if [ -z "$pairs" ]; then
+    echo "No sources found in Vorpal.lock"
+    exit 0
+fi
+
+total=$(echo "$pairs" | wc -l | tr -d ' ')
+count=0
+failed_urls=()
+
+echo "Found ${total} unique source(s) to download"
+
+while IFS=' ' read -r platform url; do
+    count=$((count + 1))
+    filename=$(basename "${url%%\?*}")
+    target_dir="${SOURCE_DIR}/${platform}"
+    target_file="${target_dir}/${filename}"
+
+    if [ -f "$target_file" ]; then
+        echo "[${count}/${total}] Skipping (exists): ${platform}/${filename}"
+        continue
+    fi
+
+    mkdir -p "$target_dir"
+    echo "[${count}/${total}] Downloading: ${platform}/${filename}"
+    if ! curl -fSL -o "$target_file" "$url"; then
+        echo "Warning: Failed to download ${platform}/${filename} from ${url}" >&2
+        rm -f "$target_file"
+        failed_urls+=("${platform} ${url}")
+        continue
+    fi
+done <<< "$pairs"
+
+if [ "${#failed_urls[@]}" -gt 0 ]; then
+    echo "" >&2
+    echo "Failed to download ${#failed_urls[@]} source(s):" >&2
+    for entry in "${failed_urls[@]}"; do
+        platform="${entry%% *}"
+        url="${entry#* }"
+        echo "  - [${platform}] ${url}" >&2
+    done
+    exit 1
+fi
+
+echo "Done"

--- a/sdk/codegen/Cargo.toml
+++ b/sdk/codegen/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-sdk-codegen"
 publish = false
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 proc-macro2 = "1"

--- a/sdk/codegen/src/main.rs
+++ b/sdk/codegen/src/main.rs
@@ -627,7 +627,7 @@ fn source_func_name_to_go(name: &str) -> String {
 }
 
 /// Build a Go fmt.Sprintf or string expression for a source path URL.
-fn build_go_source_path(template: &str, has_version_replace: bool, func_name: &str) -> String {
+fn build_go_source_path(template: &str, has_version_replace: bool, _func_name: &str) -> String {
     if template.is_empty() {
         return "\"\"".to_string();
     }
@@ -671,11 +671,6 @@ fn build_go_source_path(template: &str, has_version_replace: bool, func_name: &s
             }
         }
         remaining = &remaining[end + 1..];
-    }
-
-    // Special case: curl_cacert has no format args
-    if func_name == "curl_cacert" {
-        return format!("\"{}\"", template);
     }
 
     if args.is_empty() {
@@ -748,13 +743,9 @@ fn source_func_name_to_ts(name: &str) -> String {
 }
 
 /// Build a TypeScript template literal for a source path URL.
-fn build_ts_source_path(template: &str, has_version_replace: bool, func_name: &str) -> String {
+fn build_ts_source_path(template: &str, has_version_replace: bool, _func_name: &str) -> String {
     if template.is_empty() {
         return "\"\"".to_string();
-    }
-
-    if func_name == "curl_cacert" {
-        return format!("\"{}\"", template);
     }
 
     // Check if we need template literal (has placeholders)

--- a/sdk/go/cmd/vorpal/artifact/vorpal_shell.go
+++ b/sdk/go/cmd/vorpal/artifact/vorpal_shell.go
@@ -21,6 +21,11 @@ func BuildVorpalShell(context *config.ConfigContext) (*string, error) {
 		return nil, fmt.Errorf("failed to get crane: %w", err)
 	}
 
+	gh, err := artifact.Gh(context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gh: %w", err)
+	}
+
 	gobin, err := artifact.GoBin(context)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get go: %w", err)
@@ -66,6 +71,11 @@ func BuildVorpalShell(context *config.ConfigContext) (*string, error) {
 		return nil, fmt.Errorf("failed to get protoc-gen-go-grpc: %w", err)
 	}
 
+	rsync, err := artifact.Rsync(context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rsync: %w", err)
+	}
+
 	staticcheck, err := artifact.Staticcheck(context)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get staticcheck: %w", err)
@@ -86,6 +96,7 @@ func BuildVorpalShell(context *config.ConfigContext) (*string, error) {
 		WithArtifacts([]*string{
 			bun,
 			crane,
+			gh,
 			gobin,
 			goimports,
 			gopls,
@@ -95,6 +106,7 @@ func BuildVorpalShell(context *config.ConfigContext) (*string, error) {
 			protoc,
 			protocGenGo,
 			protocGenGoGRPC,
+			rsync,
 			staticcheck,
 		}).
 		WithEnvironments([]string{

--- a/sdk/go/pkg/artifact/bun.go
+++ b/sdk/go/pkg/artifact/bun.go
@@ -29,7 +29,7 @@ func Bun(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := defaultBunVersion
-	sourcePath := fmt.Sprintf("https://github.com/oven-sh/bun/releases/download/bun-v%s/bun-%s.zip", sourceVersion, sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/bun-%s-%s.zip", sourceVersion, sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/cargo.go
+++ b/sdk/go/pkg/artifact/cargo.go
@@ -18,7 +18,7 @@ func Cargo(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := RustToolchainVersion()
-	sourcePath := fmt.Sprintf("https://static.rust-lang.org/dist/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/clippy.go
+++ b/sdk/go/pkg/artifact/clippy.go
@@ -18,7 +18,7 @@ func Clippy(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := RustToolchainVersion()
-	sourcePath := fmt.Sprintf("https://static.rust-lang.org/dist/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/crane.go
+++ b/sdk/go/pkg/artifact/crane.go
@@ -11,7 +11,7 @@ func Crane(context *config.ConfigContext) (*string, error) {
 	name := "crane"
 	version := "0.21.1"
 
-	sourcePath := fmt.Sprintf("https://github.com/google/go-containerregistry/archive/refs/tags/v%s.tar.gz", version)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/crane-v%s.tar.gz", version)
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	buildDirectory := fmt.Sprintf("./go-containerregistry-%s", version)

--- a/sdk/go/pkg/artifact/gh.go
+++ b/sdk/go/pkg/artifact/gh.go
@@ -36,7 +36,7 @@ func Gh(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := "2.87.3"
-	sourcePath := fmt.Sprintf("https://github.com/cli/cli/releases/download/v%s/gh_%s_%s.%s", sourceVersion, sourceVersion, sourceTarget, sourceExtension)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/gh_%s_%s.%s", sourceVersion, sourceTarget, sourceExtension)
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	stepScript := fmt.Sprintf(`mkdir -p "$VORPAL_OUTPUT/bin"

--- a/sdk/go/pkg/artifact/git.go
+++ b/sdk/go/pkg/artifact/git.go
@@ -12,7 +12,7 @@ func Git(context *config.ConfigContext) (*string, error) {
 
 	sourceVersion := "2.53.0"
 
-	sourcePath := fmt.Sprintf("https://www.kernel.org/pub/software/scm/git/git-%s.tar.gz", sourceVersion)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/git-%s.tar.gz", sourceVersion)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/gobin.go
+++ b/sdk/go/pkg/artifact/gobin.go
@@ -9,7 +9,7 @@ import (
 
 func sourceTools(name string) api.ArtifactSource {
 	version := "0.42.0"
-	path := fmt.Sprintf("https://go.googlesource.com/tools/+archive/refs/tags/v%s.tar.gz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/go-tools-v%s.tar.gz", version)
 	return NewArtifactSource(name, path).Build()
 }
 
@@ -33,7 +33,7 @@ func GoBin(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := "1.26.0"
-	sourcePath := fmt.Sprintf("https://go.dev/dl/go%s.%s.tar.gz", sourceVersion, sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/go%s.%s.tar.gz", sourceVersion, sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/grpcurl.go
+++ b/sdk/go/pkg/artifact/grpcurl.go
@@ -11,7 +11,7 @@ func Grpcurl(context *config.ConfigContext) (*string, error) {
 	name := "grpcurl"
 	version := "1.9.3"
 
-	sourcePath := fmt.Sprintf("https://github.com/fullstorydev/grpcurl/archive/refs/tags/v%s.tar.gz", version)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/grpcurl-v%s.tar.gz", version)
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	buildDirectory := fmt.Sprintf("%s-%s", name, version)

--- a/sdk/go/pkg/artifact/linux_vorpal_build.go
+++ b/sdk/go/pkg/artifact/linux_vorpal_build.go
@@ -13,6 +13,7 @@ func linuxVorpalBuild(ctx *config.ConfigContext) (*string, error) {
 	bisonVersion := "3.8.2"
 	coreutilsVersion := "9.7"
 	curlVersion := "8.15.0"
+	curlCacertVersion := "1776122862"
 	diffutilsVersion := "3.12"
 	fileVersion := "5.46"
 	findutilsVersion := "4.10.0"
@@ -49,7 +50,7 @@ func linuxVorpalBuild(ctx *config.ConfigContext) (*string, error) {
 	bison := linuxVorpalSourceGnu("bison", bisonVersion)
 	coreutils := linuxVorpalSourceGnu("coreutils", coreutilsVersion)
 	curl := linuxVorpalSourceCurl(curlVersion)
-	curlCacert := linuxVorpalSourceCurlCacert()
+	curlCacert := linuxVorpalSourceCurlCacert(curlCacertVersion)
 	diffutils := linuxVorpalSourceGnuXz("diffutils", diffutilsVersion)
 	file := linuxVorpalSourceFile(fileVersion)
 	findutils := linuxVorpalSourceGnuXz("findutils", findutilsVersion)

--- a/sdk/go/pkg/artifact/linux_vorpal_source.go
+++ b/sdk/go/pkg/artifact/linux_vorpal_source.go
@@ -11,110 +11,110 @@ import (
 
 func linuxVorpalSourceCurl(version string) api.ArtifactSource {
 	name := "curl"
-	path := fmt.Sprintf("https://curl.se/download/%s-%s.tar.xz", name, version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s.tar.xz", name, version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
-func linuxVorpalSourceCurlCacert() api.ArtifactSource {
+func linuxVorpalSourceCurlCacert(version string) api.ArtifactSource {
 	name := "curl-cacert"
-	path := "https://curl.se/ca/cacert.pem"
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/cacert-%s.pem", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceFile(version string) api.ArtifactSource {
 	name := "file"
-	path := fmt.Sprintf("https://astron.com/pub/file/file-%s.tar.gz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/file-%s.tar.gz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceGnu(name string, version string) api.ArtifactSource {
-	path := fmt.Sprintf("https://ftpmirror.gnu.org/gnu/%s/%s-%s.tar.gz", name, name, version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s.tar.gz", name, version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceGnuXz(name string, version string) api.ArtifactSource {
-	path := fmt.Sprintf("https://ftpmirror.gnu.org/gnu/%s/%s-%s.tar.xz", name, name, version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s.tar.xz", name, version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceGnuGcc(version string) api.ArtifactSource {
 	name := "gcc"
-	path := fmt.Sprintf("https://ftpmirror.gnu.org/gnu/gcc/gcc-%s/gcc-%s.tar.xz", version, version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/gcc-%s.tar.xz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceGnuGlibcPatch(version string) api.ArtifactSource {
 	name := "glibc-patch"
-	path := fmt.Sprintf("https://www.linuxfromscratch.org/patches/lfs/12.4/glibc-%s-fhs-1.patch", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/glibc-%s-fhs-1.patch", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceLibidn2(version string) api.ArtifactSource {
 	name := "libidn2"
-	path := fmt.Sprintf("https://ftpmirror.gnu.org/gnu/libidn/libidn2-%s.tar.gz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/libidn2-%s.tar.gz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceLibpsl(version string) api.ArtifactSource {
 	name := "libpsl"
-	path := fmt.Sprintf("https://github.com/rockdaboot/libpsl/releases/download/%s/libpsl-%s.tar.gz", version, version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/libpsl-%s.tar.gz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceLinux(version string) api.ArtifactSource {
 	name := "linux"
-	path := fmt.Sprintf("https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%s.tar.xz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/linux-%s.tar.xz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceNcurses(version string) api.ArtifactSource {
 	name := "ncurses"
-	path := fmt.Sprintf("https://invisible-mirror.net/archives/ncurses/current/ncurses-%s.tgz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/ncurses-%s.tar.gz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceOpenssl(version string) api.ArtifactSource {
 	name := "openssl"
-	path := fmt.Sprintf("https://www.openssl.org/source/openssl-%s.tar.gz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/openssl-%s.tar.gz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourcePerl(version string) api.ArtifactSource {
 	name := "perl"
-	path := fmt.Sprintf("https://www.cpan.org/src/5.0/perl-%s.tar.xz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/perl-%s.tar.xz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourcePython(version string) api.ArtifactSource {
 	name := "python"
-	path := fmt.Sprintf("https://www.python.org/ftp/python/%s/Python-%s.tar.xz", version, version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/Python-%s.tar.xz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceUnzipPatchFixes(version string) api.ArtifactSource {
 	name := "unzip-patch-fixes"
-	path := fmt.Sprintf("https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-%s-consolidated_fixes-1.patch", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/unzip-%s-consolidated_fixes-1.patch", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceUnzipPatchGcc14(version string) api.ArtifactSource {
 	name := "unzip-patch-gcc14"
-	path := fmt.Sprintf("https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-%s-gcc14-1.patch", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/unzip-%s-gcc14-1.patch", version)
 
 	return NewArtifactSource(name, path).Build()
 }
@@ -122,28 +122,28 @@ func linuxVorpalSourceUnzipPatchGcc14(version string) api.ArtifactSource {
 func linuxVorpalSourceUnzip(version string) api.ArtifactSource {
 	name := "unzip"
 	versionClean := strings.ReplaceAll(version, ".", "")
-	path := fmt.Sprintf("https://cytranet-dal.dl.sourceforge.net/project/infozip/UnZip%%206.x%%20%%28latest%%29/UnZip%%206.0/unzip%s.tar.gz?viasf=1", versionClean)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/unzip%s.tar.gz", versionClean)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceUtilLinux(version string) api.ArtifactSource {
 	name := "util-linux"
-	path := fmt.Sprintf("https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-%s.tar.xz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/util-linux-%s.tar.xz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceXz(version string) api.ArtifactSource {
 	name := "xz"
-	path := fmt.Sprintf("https://github.com/tukaani-project/xz/releases/download/v%s/xz-%s.tar.xz", version, version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/xz-%s.tar.xz", version)
 
 	return NewArtifactSource(name, path).Build()
 }
 
 func linuxVorpalSourceZlib(version string) api.ArtifactSource {
 	name := "zlib"
-	path := fmt.Sprintf("https://zlib.net/fossils/zlib-%s.tar.gz", version)
+	path := fmt.Sprintf("https://sdk.vorpal.build/source/zlib-%s.tar.gz", version)
 
 	return NewArtifactSource(name, path).Build()
 }

--- a/sdk/go/pkg/artifact/nodejs.go
+++ b/sdk/go/pkg/artifact/nodejs.go
@@ -28,8 +28,8 @@ func NodeJS(context *config.ConfigContext) (*string, error) {
 
 	sourceVersion := "22.22.0"
 	sourcePath := fmt.Sprintf(
-		"https://nodejs.org/dist/v%s/node-v%s-%s.tar.gz",
-		sourceVersion, sourceVersion, sourceTarget,
+		"https://sdk.vorpal.build/source/node-v%s-%s.tar.gz",
+		sourceVersion, sourceTarget,
 	)
 
 	source := NewArtifactSource(name, sourcePath).Build()

--- a/sdk/go/pkg/artifact/pnpm.go
+++ b/sdk/go/pkg/artifact/pnpm.go
@@ -26,7 +26,7 @@ func Pnpm(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := "10.30.3"
-	sourcePath := fmt.Sprintf("https://github.com/pnpm/pnpm/releases/download/v%s/pnpm-%s", sourceVersion, sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/pnpm-%s-%s", sourceVersion, sourceTarget)
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	stepScript := fmt.Sprintf(`mkdir -p "$VORPAL_OUTPUT/bin"

--- a/sdk/go/pkg/artifact/protoc.go
+++ b/sdk/go/pkg/artifact/protoc.go
@@ -27,7 +27,7 @@ func Protoc(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := "34.0"
-	sourcePath := fmt.Sprintf("https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s.zip", sourceVersion, sourceVersion, sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/protoc-%s-%s.zip", sourceVersion, sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/protoc_gen_go.go
+++ b/sdk/go/pkg/artifact/protoc_gen_go.go
@@ -27,7 +27,7 @@ func ProtocGenGo(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := "1.36.11"
-	sourcePath := fmt.Sprintf("https://github.com/protocolbuffers/protobuf-go/releases/download/v%s/protoc-gen-go.v%s.%s.tar.gz", sourceVersion, sourceVersion, sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/protoc-gen-go.v%s.%s.tar.gz", sourceVersion, sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/protoc_gen_go_grpc.go
+++ b/sdk/go/pkg/artifact/protoc_gen_go_grpc.go
@@ -11,7 +11,7 @@ func ProtocGenGoGRPC(context *config.ConfigContext) (*string, error) {
 	name := "protoc-gen-go-grpc"
 	version := "1.79.1"
 
-	sourcePath := fmt.Sprintf("https://github.com/grpc/grpc-go/archive/refs/tags/v%s.tar.gz", version)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/protoc-gen-go-grpc-v%s.tar.gz", version)
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	buildDirectory := fmt.Sprintf("grpc-go-%s/cmd/%s", version, name)

--- a/sdk/go/pkg/artifact/rsync.go
+++ b/sdk/go/pkg/artifact/rsync.go
@@ -11,7 +11,7 @@ func Rsync(context *config.ConfigContext) (*string, error) {
 	name := "rsync"
 	version := "3.4.1"
 
-	sourcePath := fmt.Sprintf("https://download.samba.org/pub/rsync/src/rsync-%s.tar.gz", version)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/rsync-%s.tar.gz", version)
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	stepScript := fmt.Sprintf(`mkdir -p "$VORPAL_OUTPUT"

--- a/sdk/go/pkg/artifact/rust_analyzer.go
+++ b/sdk/go/pkg/artifact/rust_analyzer.go
@@ -18,7 +18,7 @@ func RustAnalyzer(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := RustToolchainVersion()
-	sourcePath := fmt.Sprintf("https://static.rust-lang.org/dist/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/rust_src.go
+++ b/sdk/go/pkg/artifact/rust_src.go
@@ -11,7 +11,7 @@ func RustSrc(context *config.ConfigContext) (*string, error) {
 	name := "rust-src"
 
 	sourceVersion := RustToolchainVersion()
-	sourcePath := fmt.Sprintf("https://static.rust-lang.org/dist/rust-src-%s.tar.gz", sourceVersion)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/rust-src-%s.tar.gz", sourceVersion)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/rust_std.go
+++ b/sdk/go/pkg/artifact/rust_std.go
@@ -18,7 +18,7 @@ func RustStd(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := RustToolchainVersion()
-	sourcePath := fmt.Sprintf("https://static.rust-lang.org/dist/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/rustc.go
+++ b/sdk/go/pkg/artifact/rustc.go
@@ -18,7 +18,7 @@ func Rustc(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := RustToolchainVersion()
-	sourcePath := fmt.Sprintf("https://static.rust-lang.org/dist/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/rustfmt.go
+++ b/sdk/go/pkg/artifact/rustfmt.go
@@ -18,7 +18,7 @@ func Rustfmt(context *config.ConfigContext) (*string, error) {
 	}
 
 	sourceVersion := RustToolchainVersion()
-	sourcePath := fmt.Sprintf("https://static.rust-lang.org/dist/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/%s-%s-%s.tar.gz", name, sourceVersion, *sourceTarget)
 
 	source := NewArtifactSource(name, sourcePath).Build()
 

--- a/sdk/go/pkg/artifact/staticcheck.go
+++ b/sdk/go/pkg/artifact/staticcheck.go
@@ -11,7 +11,7 @@ func Staticcheck(context *config.ConfigContext) (*string, error) {
 	name := "staticcheck"
 	version := "2026.1"
 
-	sourcePath := fmt.Sprintf("https://github.com/dominikh/go-tools/archive/refs/tags/%s.tar.gz", version)
+	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/staticcheck-%s.tar.gz", version)
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	buildDirectory := fmt.Sprintf("go-tools-%s", version)

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "vorpal-sdk"
 repository = "https://github.com/ALT-F4-LLC/vorpal"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 anyhow = { version = "1.0.100" }

--- a/sdk/rust/src/artifact/bun.rs
+++ b/sdk/rust/src/artifact/bun.rs
@@ -44,7 +44,8 @@ impl Bun {
         };
 
         let source_version = &self.version;
-        let source_path = format!("https://github.com/oven-sh/bun/releases/download/bun-v{source_version}/bun-{source_target}.zip");
+        let source_path =
+            format!("https://sdk.vorpal.build/source/bun-{source_version}-{source_target}.zip");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/rust/src/artifact/cargo.rs
+++ b/sdk/rust/src/artifact/cargo.rs
@@ -20,7 +20,7 @@ impl Cargo {
         let source_target = rust_toolchain::target(system)?;
         let source_version = rust_toolchain::version();
         let source_path = format!(
-            "https://static.rust-lang.org/dist/{name}-{source_version}-{source_target}.tar.gz"
+            "https://sdk.vorpal.build/source/{name}-{source_version}-{source_target}.tar.gz"
         );
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();

--- a/sdk/rust/src/artifact/clippy.rs
+++ b/sdk/rust/src/artifact/clippy.rs
@@ -20,7 +20,7 @@ impl Clippy {
         let source_target = rust_toolchain::target(system)?;
         let source_version = rust_toolchain::version();
         let source_path = format!(
-            "https://static.rust-lang.org/dist/{name}-{source_version}-{source_target}.tar.gz"
+            "https://sdk.vorpal.build/source/{name}-{source_version}-{source_target}.tar.gz"
         );
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();

--- a/sdk/rust/src/artifact/crane.rs
+++ b/sdk/rust/src/artifact/crane.rs
@@ -17,9 +17,7 @@ impl Crane {
         let name = "crane";
         let version = "0.21.1";
 
-        let source_path = format!(
-            "https://github.com/google/go-containerregistry/archive/refs/tags/v{version}.tar.gz"
-        );
+        let source_path = format!("https://sdk.vorpal.build/source/crane-v{version}.tar.gz");
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 
         let build_directory = format!("./go-containerregistry-{version}");

--- a/sdk/rust/src/artifact/gh.rs
+++ b/sdk/rust/src/artifact/gh.rs
@@ -33,7 +33,7 @@ impl Gh {
         };
 
         let source_version = "2.87.3";
-        let source_path = format!("https://github.com/cli/cli/releases/download/v{source_version}/gh_{source_version}_{source_target}.{source_extension}");
+        let source_path = format!("https://sdk.vorpal.build/source/gh_{source_version}_{source_target}.{source_extension}");
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 
         let step_script = formatdoc! {"

--- a/sdk/rust/src/artifact/git.rs
+++ b/sdk/rust/src/artifact/git.rs
@@ -19,8 +19,7 @@ impl Git {
 
         let source_version = "2.53.0";
 
-        let source_path =
-            format!("https://www.kernel.org/pub/software/scm/git/git-{source_version}.tar.gz");
+        let source_path = format!("https://sdk.vorpal.build/source/git-{source_version}.tar.gz");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/rust/src/artifact/go.rs
+++ b/sdk/rust/src/artifact/go.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Result};
 pub fn source_tools(name: &str) -> api::artifact::ArtifactSource {
     let version = "0.42.0";
 
-    let path = format!("https://go.googlesource.com/tools/+archive/refs/tags/v{version}.tar.gz");
+    let path = format!("https://sdk.vorpal.build/source/go-tools-v{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
@@ -36,7 +36,8 @@ impl Go {
         };
 
         let source_version = "1.26.0";
-        let source_path = format!("https://go.dev/dl/go{source_version}.{source_target}.tar.gz");
+        let source_path =
+            format!("https://sdk.vorpal.build/source/go{source_version}.{source_target}.tar.gz");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/rust/src/artifact/grpcurl.rs
+++ b/sdk/rust/src/artifact/grpcurl.rs
@@ -29,9 +29,8 @@ impl<'a> Grpcurl<'a> {
         let name = "grpcurl";
 
         let source_version = "1.9.3";
-        let source_path = format!(
-            "https://github.com/fullstorydev/grpcurl/archive/refs/tags/v{source_version}.tar.gz"
-        );
+        let source_path =
+            format!("https://sdk.vorpal.build/source/grpcurl-v{source_version}.tar.gz");
 
         let source = ArtifactSource::new(name, &source_path).build();
 

--- a/sdk/rust/src/artifact/linux_vorpal.rs
+++ b/sdk/rust/src/artifact/linux_vorpal.rs
@@ -36,7 +36,9 @@ impl LinuxVorpal {
 
         let curl_version = "8.15.0";
         let curl = source::curl(curl_version);
-        let curl_cacert = source::curl_cacert();
+
+        let curl_cacert_version = "1776122862";
+        let curl_cacert = source::curl_cacert(curl_cacert_version);
 
         let diffutils_version = "3.12";
         let diffutils = source::gnu_xz("diffutils", diffutils_version);

--- a/sdk/rust/src/artifact/linux_vorpal/source.rs
+++ b/sdk/rust/src/artifact/linux_vorpal/source.rs
@@ -2,116 +2,111 @@ use crate::{api, artifact::ArtifactSource};
 
 pub fn curl(version: &str) -> api::artifact::ArtifactSource {
     let name = "curl";
-    let path = format!("https://curl.se/download/{name}-{version}.tar.xz");
+    let path = format!("https://sdk.vorpal.build/source/{name}-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
-pub fn curl_cacert() -> api::artifact::ArtifactSource {
+pub fn curl_cacert(version: &str) -> api::artifact::ArtifactSource {
     let name = "curl-cacert";
-    let path = "https://curl.se/ca/cacert.pem";
+    let path = format!("https://sdk.vorpal.build/source/cacert-{version}.pem");
 
-    ArtifactSource::new(name, path).build()
+    ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn file(version: &str) -> api::artifact::ArtifactSource {
     let name = "file";
-    let path = format!("https://astron.com/pub/file/file-{version}.tar.gz");
+    let path = format!("https://sdk.vorpal.build/source/file-{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn gnu(name: &str, version: &str) -> api::artifact::ArtifactSource {
-    let path = format!("https://ftpmirror.gnu.org/gnu/{name}/{name}-{version}.tar.gz");
+    let path = format!("https://sdk.vorpal.build/source/{name}-{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn gnu_xz(name: &str, version: &str) -> api::artifact::ArtifactSource {
-    let path = format!("https://ftpmirror.gnu.org/gnu/{name}/{name}-{version}.tar.xz");
+    let path = format!("https://sdk.vorpal.build/source/{name}-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn gnu_gcc(version: &str) -> api::artifact::ArtifactSource {
     let name = "gcc";
-    let path = format!("https://ftpmirror.gnu.org/gnu/gcc/gcc-{version}/gcc-{version}.tar.xz");
+    let path = format!("https://sdk.vorpal.build/source/gcc-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn gnu_glibc_patch(version: &str) -> api::artifact::ArtifactSource {
     let name = "glibc-patch";
-    let path =
-        format!("https://www.linuxfromscratch.org/patches/lfs/12.4/glibc-{version}-fhs-1.patch");
+    let path = format!("https://sdk.vorpal.build/source/glibc-{version}-fhs-1.patch");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn libidn2(version: &str) -> api::artifact::ArtifactSource {
     let name = "libidn2";
-    let path = format!("https://ftpmirror.gnu.org/gnu/libidn/libidn2-{version}.tar.gz");
+    let path = format!("https://sdk.vorpal.build/source/libidn2-{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn libpsl(version: &str) -> api::artifact::ArtifactSource {
     let name = "libpsl";
-    let path = format!(
-        "https://github.com/rockdaboot/libpsl/releases/download/{version}/libpsl-{version}.tar.gz",
-    );
+    let path = format!("https://sdk.vorpal.build/source/libpsl-{version}.tar.gz",);
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn linux(version: &str) -> api::artifact::ArtifactSource {
     let name = "linux";
-    let path = format!("https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-{version}.tar.xz");
+    let path = format!("https://sdk.vorpal.build/source/linux-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn ncurses(version: &str) -> api::artifact::ArtifactSource {
     let name = "ncurses";
-    let path =
-        format!("https://invisible-mirror.net/archives/ncurses/current/ncurses-{version}.tgz");
+    let path = format!("https://sdk.vorpal.build/source/ncurses-{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn openssl(version: &str) -> api::artifact::ArtifactSource {
     let name = "openssl";
-    let path = format!("https://www.openssl.org/source/openssl-{version}.tar.gz");
+    let path = format!("https://sdk.vorpal.build/source/openssl-{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn perl(version: &str) -> api::artifact::ArtifactSource {
     let name = "perl";
-    let path = format!("https://www.cpan.org/src/5.0/perl-{version}.tar.xz");
+    let path = format!("https://sdk.vorpal.build/source/perl-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn python(version: &str) -> api::artifact::ArtifactSource {
     let name = "python";
-    let path = format!("https://www.python.org/ftp/python/{version}/Python-{version}.tar.xz");
+    let path = format!("https://sdk.vorpal.build/source/Python-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn unzip_patch_fixes(version: &str) -> api::artifact::ArtifactSource {
     let name = "unzip-patch-fixes";
-    let path = format!("https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-{version}-consolidated_fixes-1.patch");
+    let path =
+        format!("https://sdk.vorpal.build/source/unzip-{version}-consolidated_fixes-1.patch");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn unzip_patch_gcc14(version: &str) -> api::artifact::ArtifactSource {
     let name = "unzip-patch-gcc14";
-    let path = format!(
-        "https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-{version}-gcc14-1.patch"
-    );
+    let path = format!("https://sdk.vorpal.build/source/unzip-{version}-gcc14-1.patch");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
@@ -119,32 +114,28 @@ pub fn unzip_patch_gcc14(version: &str) -> api::artifact::ArtifactSource {
 pub fn unzip(version: &str) -> api::artifact::ArtifactSource {
     let name = "unzip";
     let version = version.replace(".", "");
-    let path = format!("https://cytranet-dal.dl.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip{version}.tar.gz?viasf=1");
+    let path = format!("https://sdk.vorpal.build/source/unzip{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn util_linux(version: &str) -> api::artifact::ArtifactSource {
     let name = "util-linux";
-    let path = format!(
-        "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-{version}.tar.xz"
-    );
+    let path = format!("https://sdk.vorpal.build/source/util-linux-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn xz(version: &str) -> api::artifact::ArtifactSource {
     let name = "xz";
-    let path = format!(
-        "https://github.com/tukaani-project/xz/releases/download/v{version}/xz-{version}.tar.xz"
-    );
+    let path = format!("https://sdk.vorpal.build/source/xz-{version}.tar.xz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }
 
 pub fn zlib(version: &str) -> api::artifact::ArtifactSource {
     let name = "zlib";
-    let path = format!("https://zlib.net/fossils/zlib-{version}.tar.gz");
+    let path = format!("https://sdk.vorpal.build/source/zlib-{version}.tar.gz");
 
     ArtifactSource::new(name, path.as_str()).build()
 }

--- a/sdk/rust/src/artifact/nodejs.rs
+++ b/sdk/rust/src/artifact/nodejs.rs
@@ -28,7 +28,7 @@ impl NodeJS {
 
         let source_version = "22.22.0";
         let source_path = format!(
-            "https://nodejs.org/dist/v{source_version}/node-v{source_version}-{source_target}.tar.gz"
+            "https://sdk.vorpal.build/source/node-v{source_version}-{source_target}.tar.gz"
         );
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();

--- a/sdk/rust/src/artifact/pnpm.rs
+++ b/sdk/rust/src/artifact/pnpm.rs
@@ -28,9 +28,8 @@ impl Pnpm {
         };
 
         let source_version = "10.30.3";
-        let source_path = format!(
-            "https://github.com/pnpm/pnpm/releases/download/v{source_version}/pnpm-{source_target}"
-        );
+        let source_path =
+            format!("https://sdk.vorpal.build/source/pnpm-{source_version}-{source_target}");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/rust/src/artifact/protoc.rs
+++ b/sdk/rust/src/artifact/protoc.rs
@@ -27,7 +27,8 @@ impl Protoc {
         };
 
         let source_version = "34.0";
-        let source_path = format!("https://github.com/protocolbuffers/protobuf/releases/download/v{source_version}/protoc-{source_version}-{source_target}.zip");
+        let source_path =
+            format!("https://sdk.vorpal.build/source/protoc-{source_version}-{source_target}.zip");
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 
         let step_script = formatdoc! {"

--- a/sdk/rust/src/artifact/protoc_gen_go.rs
+++ b/sdk/rust/src/artifact/protoc_gen_go.rs
@@ -27,7 +27,7 @@ impl ProtocGenGo {
         };
 
         let source_version = "1.36.11";
-        let source_path = format!("https://github.com/protocolbuffers/protobuf-go/releases/download/v{source_version}/protoc-gen-go.v{source_version}.{source_target}.tar.gz");
+        let source_path = format!("https://sdk.vorpal.build/source/protoc-gen-go.v{source_version}.{source_target}.tar.gz");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/rust/src/artifact/protoc_gen_go_grpc.rs
+++ b/sdk/rust/src/artifact/protoc_gen_go_grpc.rs
@@ -18,7 +18,7 @@ impl ProtocGenGoGrpc {
 
         let source_version = "1.79.1";
         let source_path =
-            format!("https://github.com/grpc/grpc-go/archive/refs/tags/v{source_version}.tar.gz");
+            format!("https://sdk.vorpal.build/source/protoc-gen-go-grpc-v{source_version}.tar.gz");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/rust/src/artifact/rsync.rs
+++ b/sdk/rust/src/artifact/rsync.rs
@@ -18,7 +18,7 @@ impl Rsync {
         let name = "rsync";
         let version = "3.4.1";
 
-        let path = format!("https://download.samba.org/pub/rsync/src/rsync-{version}.tar.gz");
+        let path = format!("https://sdk.vorpal.build/source/rsync-{version}.tar.gz");
         let source = ArtifactSource::new(name, &path).build();
 
         let step_script = formatdoc! {"

--- a/sdk/rust/src/artifact/rust_analyzer.rs
+++ b/sdk/rust/src/artifact/rust_analyzer.rs
@@ -20,7 +20,7 @@ impl RustAnalyzer {
         let source_target = rust_toolchain::target(system)?;
         let source_version = rust_toolchain::version();
         let source_path = format!(
-            "https://static.rust-lang.org/dist/{name}-{source_version}-{source_target}.tar.gz"
+            "https://sdk.vorpal.build/source/{name}-{source_version}-{source_target}.tar.gz"
         );
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();

--- a/sdk/rust/src/artifact/rust_src.rs
+++ b/sdk/rust/src/artifact/rust_src.rs
@@ -17,7 +17,7 @@ impl RustSrc {
         let name = "rust-src";
         let source_version = rust_toolchain::version();
         let source_path =
-            format!("https://static.rust-lang.org/dist/rust-src-{source_version}.tar.gz");
+            format!("https://sdk.vorpal.build/source/rust-src-{source_version}.tar.gz");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/rust/src/artifact/rust_std.rs
+++ b/sdk/rust/src/artifact/rust_std.rs
@@ -20,7 +20,7 @@ impl RustStd {
         let source_target = rust_toolchain::target(system)?;
         let source_version = rust_toolchain::version();
         let source_path = format!(
-            "https://static.rust-lang.org/dist/{name}-{source_version}-{source_target}.tar.gz"
+            "https://sdk.vorpal.build/source/{name}-{source_version}-{source_target}.tar.gz"
         );
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();

--- a/sdk/rust/src/artifact/rustc.rs
+++ b/sdk/rust/src/artifact/rustc.rs
@@ -20,7 +20,7 @@ impl Rustc {
         let source_target = rust_toolchain::target(system)?;
         let source_version = rust_toolchain::version();
         let source_path = format!(
-            "https://static.rust-lang.org/dist/{name}-{source_version}-{source_target}.tar.gz"
+            "https://sdk.vorpal.build/source/{name}-{source_version}-{source_target}.tar.gz"
         );
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();

--- a/sdk/rust/src/artifact/rustfmt.rs
+++ b/sdk/rust/src/artifact/rustfmt.rs
@@ -20,7 +20,7 @@ impl Rustfmt {
         let source_target = rust_toolchain::target(system)?;
         let source_version = rust_toolchain::version();
         let source_path = format!(
-            "https://static.rust-lang.org/dist/{name}-{source_version}-{source_target}.tar.gz"
+            "https://sdk.vorpal.build/source/{name}-{source_version}-{source_target}.tar.gz"
         );
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();

--- a/sdk/rust/src/artifact/staticcheck.rs
+++ b/sdk/rust/src/artifact/staticcheck.rs
@@ -16,9 +16,8 @@ impl Staticcheck {
     pub async fn build(self, context: &mut ConfigContext) -> Result<String> {
         let name = "staticcheck";
         let source_version = "2026.1";
-        let source_path = format!(
-            "https://github.com/dominikh/go-tools/archive/refs/tags/{source_version}.tar.gz"
-        );
+        let source_path =
+            format!("https://sdk.vorpal.build/source/staticcheck-{source_version}.tar.gz");
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altf4llc/vorpal-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for building Vorpal artifacts.",
   "license": "Apache-2.0",
   "repository": {

--- a/sdk/typescript/src/artifact/bun.ts
+++ b/sdk/typescript/src/artifact/bun.ts
@@ -47,7 +47,7 @@ export class Bun {
     }
 
     const sourceVersion = this.version;
-    const sourcePath = `https://github.com/oven-sh/bun/releases/download/bun-v${sourceVersion}/bun-${sourceTarget}.zip`;
+    const sourcePath = `https://sdk.vorpal.build/source/bun-${sourceVersion}-${sourceTarget}.zip`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/cargo.ts
+++ b/sdk/typescript/src/artifact/cargo.ts
@@ -17,7 +17,7 @@ export class Cargo {
 
     const sourceTarget = rustToolchainTarget(system);
     const sourceVersion = RUST_TOOLCHAIN_VERSION;
-    const sourcePath = `https://static.rust-lang.org/dist/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/clippy.ts
+++ b/sdk/typescript/src/artifact/clippy.ts
@@ -17,7 +17,7 @@ export class Clippy {
 
     const sourceTarget = rustToolchainTarget(system);
     const sourceVersion = RUST_TOOLCHAIN_VERSION;
-    const sourcePath = `https://static.rust-lang.org/dist/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/crane.ts
+++ b/sdk/typescript/src/artifact/crane.ts
@@ -14,7 +14,7 @@ export class Crane {
     const name = "crane";
     const version = "0.21.1";
 
-    const sourcePath = `https://github.com/google/go-containerregistry/archive/refs/tags/v${version}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/crane-v${version}.tar.gz`;
     const source = new ArtifactSource(name, sourcePath).build();
 
     const buildDirectory = `./go-containerregistry-${version}`;

--- a/sdk/typescript/src/artifact/gh.ts
+++ b/sdk/typescript/src/artifact/gh.ts
@@ -41,7 +41,7 @@ export class Gh {
     }
 
     const sourceVersion = DEFAULT_GH_VERSION;
-    const sourcePath = `https://github.com/cli/cli/releases/download/v${sourceVersion}/gh_${sourceVersion}_${sourceTarget}.${sourceExtension}`;
+    const sourcePath = `https://sdk.vorpal.build/source/gh_${sourceVersion}_${sourceTarget}.${sourceExtension}`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/gh.ts
+++ b/sdk/typescript/src/artifact/gh.ts
@@ -49,8 +49,7 @@ export class Gh {
 
 cp -pr "source/${name}/gh_${sourceVersion}_${sourceTarget}/bin/gh" "$VORPAL_OUTPUT/bin/gh"
 
-chmod +x "$VORPAL_OUTPUT/bin/gh"
-`;
+chmod +x "$VORPAL_OUTPUT/bin/gh"`;
     const steps = [await shell(context, [], [], stepScript, [])];
     const systems = [
       ArtifactSystem.AARCH64_DARWIN,

--- a/sdk/typescript/src/artifact/git.ts
+++ b/sdk/typescript/src/artifact/git.ts
@@ -15,7 +15,7 @@ export class Git {
 
     const sourceVersion = "2.53.0";
 
-    const sourcePath = `https://www.kernel.org/pub/software/scm/git/git-${sourceVersion}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/git-${sourceVersion}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/go.ts
+++ b/sdk/typescript/src/artifact/go.ts
@@ -14,7 +14,7 @@ import { shell } from "./step.js";
  */
 export function sourceTools(name: string): ArtifactSourceMsg {
   const version = "0.42.0";
-  const path = `https://go.googlesource.com/tools/+archive/refs/tags/v${version}.tar.gz`;
+  const path = `https://sdk.vorpal.build/source/go-tools-v${version}.tar.gz`;
   return new ArtifactSource(name, path).build();
 }
 
@@ -53,7 +53,7 @@ export class GoBin {
     }
 
     const sourceVersion = "1.26.0";
-    const sourcePath = `https://go.dev/dl/go${sourceVersion}.${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/go${sourceVersion}.${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/grpcurl.ts
+++ b/sdk/typescript/src/artifact/grpcurl.ts
@@ -31,7 +31,7 @@ export class Grpcurl {
     const name = "grpcurl";
 
     const sourceVersion = "1.9.3";
-    const sourcePath = `https://github.com/fullstorydev/grpcurl/archive/refs/tags/v${sourceVersion}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/grpcurl-v${sourceVersion}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/linux_vorpal/linux_vorpal.ts
+++ b/sdk/typescript/src/artifact/linux_vorpal/linux_vorpal.ts
@@ -42,6 +42,7 @@ export async function linuxVorpal(ctx: ConfigContext): Promise<string> {
   const bisonVersion = "3.8.2";
   const coreutilsVersion = "9.7";
   const curlVersion = "8.15.0";
+  const curlCacertVersion = "1776122862";
   const diffutilsVersion = "3.12";
   const fileVersion = "5.46";
   const findutilsVersion = "4.10.0";
@@ -78,7 +79,7 @@ export async function linuxVorpal(ctx: ConfigContext): Promise<string> {
   const bison = sourceGnu("bison", bisonVersion);
   const coreutils = sourceGnu("coreutils", coreutilsVersion);
   const curl = sourceCurl(curlVersion);
-  const curlCacert = sourceCurlCacert();
+  const curlCacert = sourceCurlCacert(curlCacertVersion);
   const diffutils = sourceGnuXz("diffutils", diffutilsVersion);
   const file = sourceFile(fileVersion);
   const findutils = sourceGnuXz("findutils", findutilsVersion);

--- a/sdk/typescript/src/artifact/linux_vorpal/source.ts
+++ b/sdk/typescript/src/artifact/linux_vorpal/source.ts
@@ -5,110 +5,110 @@ import { ArtifactSource as ArtifactSourceBuilder } from "../../artifact.js";
 
 export function sourceCurl(version: string): ArtifactSource {
   const name = "curl";
-  const path = `https://curl.se/download/${name}-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/${name}-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
-export function sourceCurlCacert(): ArtifactSource {
+export function sourceCurlCacert(version: string): ArtifactSource {
   const name = "curl-cacert";
-  const path = "https://curl.se/ca/cacert.pem";
+  const path = `https://sdk.vorpal.build/source/cacert-${version}.pem`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceFile(version: string): ArtifactSource {
   const name = "file";
-  const path = `https://astron.com/pub/file/file-${version}.tar.gz`;
+  const path = `https://sdk.vorpal.build/source/file-${version}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceGnu(name: string, version: string): ArtifactSource {
-  const path = `https://ftpmirror.gnu.org/gnu/${name}/${name}-${version}.tar.gz`;
+  const path = `https://sdk.vorpal.build/source/${name}-${version}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceGnuXz(name: string, version: string): ArtifactSource {
-  const path = `https://ftpmirror.gnu.org/gnu/${name}/${name}-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/${name}-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceGnuGcc(version: string): ArtifactSource {
   const name = "gcc";
-  const path = `https://ftpmirror.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/gcc-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceGnuGlibcPatch(version: string): ArtifactSource {
   const name = "glibc-patch";
-  const path = `https://www.linuxfromscratch.org/patches/lfs/12.4/glibc-${version}-fhs-1.patch`;
+  const path = `https://sdk.vorpal.build/source/glibc-${version}-fhs-1.patch`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceLibidn2(version: string): ArtifactSource {
   const name = "libidn2";
-  const path = `https://ftpmirror.gnu.org/gnu/libidn/libidn2-${version}.tar.gz`;
+  const path = `https://sdk.vorpal.build/source/libidn2-${version}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceLibpsl(version: string): ArtifactSource {
   const name = "libpsl";
-  const path = `https://github.com/rockdaboot/libpsl/releases/download/${version}/libpsl-${version}.tar.gz`;
+  const path = `https://sdk.vorpal.build/source/libpsl-${version}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceLinux(version: string): ArtifactSource {
   const name = "linux";
-  const path = `https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/linux-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceNcurses(version: string): ArtifactSource {
   const name = "ncurses";
-  const path = `https://invisible-mirror.net/archives/ncurses/current/ncurses-${version}.tgz`;
+  const path = `https://sdk.vorpal.build/source/ncurses-${version}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceOpenssl(version: string): ArtifactSource {
   const name = "openssl";
-  const path = `https://www.openssl.org/source/openssl-${version}.tar.gz`;
+  const path = `https://sdk.vorpal.build/source/openssl-${version}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourcePerl(version: string): ArtifactSource {
   const name = "perl";
-  const path = `https://www.cpan.org/src/5.0/perl-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/perl-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourcePython(version: string): ArtifactSource {
   const name = "python";
-  const path = `https://www.python.org/ftp/python/${version}/Python-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/Python-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceUnzipPatchFixes(version: string): ArtifactSource {
   const name = "unzip-patch-fixes";
-  const path = `https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-${version}-consolidated_fixes-1.patch`;
+  const path = `https://sdk.vorpal.build/source/unzip-${version}-consolidated_fixes-1.patch`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceUnzipPatchGcc14(version: string): ArtifactSource {
   const name = "unzip-patch-gcc14";
-  const path = `https://www.linuxfromscratch.org/patches/downloads/unzip/unzip-${version}-gcc14-1.patch`;
+  const path = `https://sdk.vorpal.build/source/unzip-${version}-gcc14-1.patch`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
@@ -116,28 +116,28 @@ export function sourceUnzipPatchGcc14(version: string): ArtifactSource {
 export function sourceUnzip(version: string): ArtifactSource {
   const name = "unzip";
   const versionClean = version.replaceAll(".", "");
-  const path = `https://cytranet-dal.dl.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip${versionClean}.tar.gz?viasf=1`;
+  const path = `https://sdk.vorpal.build/source/unzip${versionClean}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceUtilLinux(version: string): ArtifactSource {
   const name = "util-linux";
-  const path = `https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/util-linux-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceXz(version: string): ArtifactSource {
   const name = "xz";
-  const path = `https://github.com/tukaani-project/xz/releases/download/v${version}/xz-${version}.tar.xz`;
+  const path = `https://sdk.vorpal.build/source/xz-${version}.tar.xz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }
 
 export function sourceZlib(version: string): ArtifactSource {
   const name = "zlib";
-  const path = `https://zlib.net/fossils/zlib-${version}.tar.gz`;
+  const path = `https://sdk.vorpal.build/source/zlib-${version}.tar.gz`;
 
   return new ArtifactSourceBuilder(name, path).build();
 }

--- a/sdk/typescript/src/artifact/nodejs.ts
+++ b/sdk/typescript/src/artifact/nodejs.ts
@@ -34,7 +34,7 @@ export class NodeJS {
     }
 
     const sourceVersion = "22.22.0";
-    const sourcePath = `https://nodejs.org/dist/v${sourceVersion}/node-v${sourceVersion}-${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/node-v${sourceVersion}-${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/pnpm.ts
+++ b/sdk/typescript/src/artifact/pnpm.ts
@@ -47,7 +47,7 @@ export class Pnpm {
     }
 
     const sourceVersion = this.version;
-    const sourcePath = `https://github.com/pnpm/pnpm/releases/download/v${sourceVersion}/pnpm-${sourceTarget}`;
+    const sourcePath = `https://sdk.vorpal.build/source/pnpm-${sourceVersion}-${sourceTarget}`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/protoc.ts
+++ b/sdk/typescript/src/artifact/protoc.ts
@@ -34,7 +34,7 @@ export class Protoc {
     }
 
     const sourceVersion = "34.0";
-    const sourcePath = `https://github.com/protocolbuffers/protobuf/releases/download/v${sourceVersion}/protoc-${sourceVersion}-${sourceTarget}.zip`;
+    const sourcePath = `https://sdk.vorpal.build/source/protoc-${sourceVersion}-${sourceTarget}.zip`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/protoc_gen_go.ts
+++ b/sdk/typescript/src/artifact/protoc_gen_go.ts
@@ -34,7 +34,7 @@ export class ProtocGenGo {
     }
 
     const sourceVersion = "1.36.11";
-    const sourcePath = `https://github.com/protocolbuffers/protobuf-go/releases/download/v${sourceVersion}/protoc-gen-go.v${sourceVersion}.${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/protoc-gen-go.v${sourceVersion}.${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/protoc_gen_go_grpc.ts
+++ b/sdk/typescript/src/artifact/protoc_gen_go_grpc.ts
@@ -14,7 +14,7 @@ export class ProtocGenGoGrpc {
     const name = "protoc-gen-go-grpc";
 
     const sourceVersion = "1.79.1";
-    const sourcePath = `https://github.com/grpc/grpc-go/archive/refs/tags/v${sourceVersion}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/protoc-gen-go-grpc-v${sourceVersion}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/rsync.ts
+++ b/sdk/typescript/src/artifact/rsync.ts
@@ -15,7 +15,7 @@ export class Rsync {
 
     const version = "3.4.1";
 
-    const path = `https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz`;
+    const path = `https://sdk.vorpal.build/source/rsync-${version}.tar.gz`;
 
     const source = new ArtifactSource(name, path).build();
 

--- a/sdk/typescript/src/artifact/rust_analyzer.ts
+++ b/sdk/typescript/src/artifact/rust_analyzer.ts
@@ -17,7 +17,7 @@ export class RustAnalyzer {
 
     const sourceTarget = rustToolchainTarget(system);
     const sourceVersion = RUST_TOOLCHAIN_VERSION;
-    const sourcePath = `https://static.rust-lang.org/dist/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/rust_src.ts
+++ b/sdk/typescript/src/artifact/rust_src.ts
@@ -15,7 +15,7 @@ export class RustSrc {
   async build(context: ConfigContext): Promise<string> {
     const name = "rust-src";
     const sourceVersion = RUST_TOOLCHAIN_VERSION;
-    const sourcePath = `https://static.rust-lang.org/dist/rust-src-${sourceVersion}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/rust-src-${sourceVersion}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/rust_std.ts
+++ b/sdk/typescript/src/artifact/rust_std.ts
@@ -17,7 +17,7 @@ export class RustStd {
 
     const sourceTarget = rustToolchainTarget(system);
     const sourceVersion = RUST_TOOLCHAIN_VERSION;
-    const sourcePath = `https://static.rust-lang.org/dist/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/rustc.ts
+++ b/sdk/typescript/src/artifact/rustc.ts
@@ -17,7 +17,7 @@ export class Rustc {
 
     const sourceTarget = rustToolchainTarget(system);
     const sourceVersion = RUST_TOOLCHAIN_VERSION;
-    const sourcePath = `https://static.rust-lang.org/dist/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/rustfmt.ts
+++ b/sdk/typescript/src/artifact/rustfmt.ts
@@ -17,7 +17,7 @@ export class Rustfmt {
 
     const sourceTarget = rustToolchainTarget(system);
     const sourceVersion = RUST_TOOLCHAIN_VERSION;
-    const sourcePath = `https://static.rust-lang.org/dist/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/${name}-${sourceVersion}-${sourceTarget}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/artifact/staticcheck.ts
+++ b/sdk/typescript/src/artifact/staticcheck.ts
@@ -13,7 +13,7 @@ export class Staticcheck {
   async build(context: ConfigContext): Promise<string> {
     const name = "staticcheck";
     const sourceVersion = "2026.1";
-    const sourcePath = `https://github.com/dominikh/go-tools/archive/refs/tags/${sourceVersion}.tar.gz`;
+    const sourcePath = `https://sdk.vorpal.build/source/staticcheck-${sourceVersion}.tar.gz`;
 
     const source = new ArtifactSource(name, sourcePath).build();
 

--- a/sdk/typescript/src/vorpal.ts
+++ b/sdk/typescript/src/vorpal.ts
@@ -12,6 +12,7 @@ import {
 import { shell } from "./artifact/step.js";
 import { Bun } from "./artifact/bun.js";
 import { Crane } from "./artifact/crane.js";
+import { Gh } from "./artifact/gh.js";
 import { GoBin } from "./artifact/go.js";
 import { Goimports } from "./artifact/goimports.js";
 import { Gopls } from "./artifact/gopls.js";
@@ -22,6 +23,7 @@ import { Pnpm } from "./artifact/pnpm.js";
 import { Protoc } from "./artifact/protoc.js";
 import { ProtocGenGo } from "./artifact/protoc_gen_go.js";
 import { ProtocGenGoGrpc } from "./artifact/protoc_gen_go_grpc.js";
+import { Rsync } from "./artifact/rsync.js";
 import { Staticcheck } from "./artifact/staticcheck.js";
 import { ConfigContext } from "./context.js";
 
@@ -114,6 +116,7 @@ async function buildVorpalProcess(context: ConfigContext): Promise<string> {
 async function buildVorpalShell(context: ConfigContext): Promise<string> {
   const bun = await new Bun().build(context);
   const crane = await new Crane().build(context);
+  const gh = await new Gh().build(context);
   const go = await new GoBin().build(context);
   const goimports = await new Goimports().build(context);
   const gopls = await new Gopls().build(context);
@@ -123,6 +126,7 @@ async function buildVorpalShell(context: ConfigContext): Promise<string> {
   const protoc = await new Protoc().build(context);
   const protocGenGo = await new ProtocGenGo().build(context);
   const protocGenGoGrpc = await new ProtocGenGoGrpc().build(context);
+  const rsync = await new Rsync().build(context);
   const staticcheck = await new Staticcheck().build(context);
 
   const goarch = getGoarch(context.getSystem());
@@ -132,6 +136,7 @@ async function buildVorpalShell(context: ConfigContext): Promise<string> {
     .withArtifacts([
       bun,
       crane,
+      gh,
       go,
       goimports,
       gopls,
@@ -141,6 +146,7 @@ async function buildVorpalShell(context: ConfigContext): Promise<string> {
       protoc,
       protocGenGo,
       protocGenGoGrpc,
+      rsync,
       staticcheck,
     ])
     .withEnvironments([

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "website",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "dev": "bun x astro dev",
     "start": "bun x astro dev",

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -58,7 +58,7 @@ curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/main/script/insta
 To install a specific version without starting any services:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/main/script/install.sh | bash -s -- --version v0.1.0 --no-service
+curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/main/script/install.sh | bash -s -- --version v0.1.1 --no-service
 ```
 
 #### Environment variables
@@ -69,7 +69,7 @@ As an alternative, the installer also accepts environment variables. These are u
 |----------|--------|
 | `VORPAL_NONINTERACTIVE=1` | Enable non-interactive mode |
 | `CI=true` | Enable non-interactive mode |
-| `VORPAL_VERSION=<ver>` | Version to install (default: `0.1.0`) |
+| `VORPAL_VERSION=<ver>` | Version to install (default: `0.1.1`) |
 | `VORPAL_SERVICES=<list>` | Comma-separated services to install (default: `agent,registry,worker`) |
 | `VORPAL_NO_SERVICE=1` | Skip service installation |
 | `VORPAL_NO_PATH=1` | Skip PATH configuration |

--- a/website/src/content/docs/guides/rust.md
+++ b/website/src/content/docs/guides/rust.md
@@ -24,7 +24,7 @@ name = "vorpal"
 path = "src/vorpal.rs"
 
 [dependencies]
-vorpal-sdk = { version = "0.1.0-alpha.1" }
+vorpal-sdk = { version = "0.1.1" }
 anyhow = "1"
 tokio = { features = ["rt-multi-thread"], version = "1" }
 ```


### PR DESCRIPTION
## Overview

- migrate all SDK sources to `sdk.vorpal.build`
