### PR TITLE
fix(sdk): include version in pnpm cp source path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -207,15 +207,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -227,6 +227,7 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -255,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -266,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -278,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -306,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.132.0"
+version = "1.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5575840a3a6b11f6011463ebe359320dfe5b67babb5e9b06fed6ddf809a9ab40"
+checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -341,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.98.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -365,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.100.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -389,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.103.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -414,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -424,7 +425,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
@@ -432,7 +433,6 @@ dependencies = [
  "http 1.4.0",
  "p256",
  "percent-encoding",
- "ring",
  "sha2 0.11.0",
  "subtle",
  "time",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.7"
+version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -537,10 +537,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -565,15 +567,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -590,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -618,10 +621,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -654,13 +668,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -711,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -778,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -1019,29 +1034,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "rustversion",
  "spin 0.10.0",
 ]
 
@@ -1107,24 +1105,14 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1139,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1160,16 +1148,6 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid 0.9.6",
- "zeroize",
-]
 
 [[package]]
 name = "der"
@@ -1247,7 +1225,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1285,36 +1263,38 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.6.1",
+ "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 1.6.4",
+ "signature",
+ "spki",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
+ "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "pkcs8 0.9.0",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1366,9 +1346,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1540,6 +1520,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1585,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -2094,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2117,7 +2098,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature 2.2.0",
+ "signature",
  "simple_asn1",
  "zeroize",
 ]
@@ -2139,9 +2120,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -2352,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2441,12 +2422,13 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -2524,18 +2506,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2560,19 +2542,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -2581,8 +2553,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2638,6 +2610,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2704,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -2984,13 +2965,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
  "hmac 0.12.1",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -3019,11 +2999,11 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -3194,14 +3174,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.6.1",
+ "der",
  "generic-array",
- "pkcs8 0.9.0",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -3267,9 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3415,16 +3395,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -3497,22 +3467,12 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -3919,9 +3879,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -4114,7 +4074,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vorpal-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4164,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "indoc",
@@ -4174,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-sdk"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4198,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "vorpal-sdk-codegen"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4256,9 +4216,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4269,9 +4229,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4279,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4289,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4302,9 +4262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4345,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4629,9 +4589,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -4823,9 +4783,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-cli"
 publish = false
-version = "0.2.1"
+version = "0.2.2"
 
 [[bin]]
 name = "vorpal"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-config"
 publish = false
-version = "0.2.1"
+version = "0.2.2"
 
 [[bin]]
 name = "vorpal-config"

--- a/docs/spec/operations.md
+++ b/docs/spec/operations.md
@@ -203,7 +203,7 @@ curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/main/script/insta
 
 **Features:**
 - Platform detection (macOS/Linux, x86_64/aarch64)
-- Version selection via `VORPAL_VERSION` env var (default: `nightly`)
+- Version selection via `VORPAL_VERSION` env var (default: `0.2.2`)
 - Downloads pre-built binaries from GitHub Releases
 - Upgrade detection (preserves existing installation data)
 - Interactive/non-interactive modes (`VORPAL_NONINTERACTIVE=1`, `CI=true`, `-y` flag)

--- a/script/install.sh
+++ b/script/install.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Environment variables:
 #   VORPAL_NONINTERACTIVE=1    Enable non-interactive mode
 #   CI=true                    Enable non-interactive mode
-#   VORPAL_VERSION=<ver>       Version to install (default: 0.2.1)
+#   VORPAL_VERSION=<ver>       Version to install (default: 0.2.2)
 #   VORPAL_NO_SERVICE=1        Skip service installation
 #   VORPAL_SERVICES=<list>     Comma-separated services to install (default: agent,registry,worker)
 #   VORPAL_NO_PATH=1           Skip PATH configuration
@@ -23,7 +23,7 @@ set -euo pipefail
 
 # -- Constants ----------------------------------------------------------------
 
-VORPAL_VERSION="${VORPAL_VERSION:-0.2.1}"
+VORPAL_VERSION="${VORPAL_VERSION:-0.2.2}"
 VORPAL_INSTALL_DIR="$HOME/.vorpal"
 VORPAL_SYSTEM_DIR="/var/lib/vorpal"
 VORPAL_REPO="ALT-F4-LLC/vorpal"
@@ -361,7 +361,7 @@ Install Vorpal to ~/.vorpal and configure system services.
 
 Options:
   -y, --yes              Run in non-interactive mode (skip prompts)
-  -v, --version <ver>    Version to install (default: 0.2.1)
+  -v, --version <ver>    Version to install (default: 0.2.2)
       --services <list>  Comma-separated services to install (default: agent,registry,worker)
       --no-service       Skip service installation
       --no-path          Skip PATH configuration
@@ -376,7 +376,7 @@ Options:
 Environment variables:
   VORPAL_NONINTERACTIVE=1    Enable non-interactive mode
   CI=true                    Enable non-interactive mode
-  VORPAL_VERSION=<ver>       Version to install (default: 0.2.1)
+  VORPAL_VERSION=<ver>       Version to install (default: 0.2.2)
   VORPAL_NO_SERVICE=1        Skip service installation
   VORPAL_SERVICES=<list>     Comma-separated services (default: agent,registry,worker)
   VORPAL_NO_PATH=1           Skip PATH configuration
@@ -400,7 +400,7 @@ parse_args() {
                 if [[ $# -lt 2 ]]; then
                     print_error "Missing value for $1" \
                         "The $1 flag requires a version argument." \
-                        "Example: install.sh $1 0.2.1"
+                        "Example: install.sh $1 0.2.2"
                     exit 1
                 fi
                 VORPAL_VERSION="$2"
@@ -725,8 +725,8 @@ resolve_version() {
         http_code="$(curl -sS -o /dev/null -w "%{http_code}" "$api_url" 2>/dev/null)" || true
 
         if [[ "$http_code" = "403" ]]; then
-            print_warning "GitHub API rate limit reached. Falling back to 0.2.1."
-            version="0.2.1"
+            print_warning "GitHub API rate limit reached. Falling back to 0.2.2."
+            version="0.2.2"
         elif [[ "$http_code" = "200" ]]; then
             api_response="$(curl -fsSL "$api_url" 2>/dev/null)" || true
             if [[ -n "$api_response" ]]; then
@@ -736,16 +736,16 @@ resolve_version() {
                 if [[ -n "$tag" ]]; then
                     version="$tag"
                 else
-                    print_warning "Could not parse latest version from GitHub API. Falling back to 0.2.1."
-                    version="0.2.1"
+                    print_warning "Could not parse latest version from GitHub API. Falling back to 0.2.2."
+                    version="0.2.2"
                 fi
             else
-                print_warning "Could not fetch latest version from GitHub API. Falling back to 0.2.1."
-                version="0.2.1"
+                print_warning "Could not fetch latest version from GitHub API. Falling back to 0.2.2."
+                version="0.2.2"
             fi
         else
-            print_warning "GitHub API returned HTTP ${http_code}. Falling back to 0.2.1."
-            version="0.2.1"
+            print_warning "GitHub API returned HTTP ${http_code}. Falling back to 0.2.2."
+            version="0.2.2"
         fi
     fi
 
@@ -760,9 +760,9 @@ resolve_version() {
         print_error \
             "Version \"${VORPAL_VERSION}\" not found." \
             "Available channels:
-    ${_sym_bullet} nightly -- latest development build (updated daily)
+    ${_sym_bullet} 0.2.2   -- latest stable release
     ${_sym_bullet} latest  -- most recent stable release" \
-            "Or specify an exact tag: --version v0.2.1
+            "Or specify an exact tag: --version v0.2.2
   See all releases: ${VORPAL_GITHUB_URL}/releases"
         exit 1
     fi

--- a/sdk/codegen/Cargo.toml
+++ b/sdk/codegen/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vorpal-sdk-codegen"
 publish = false
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 proc-macro2 = "1"

--- a/sdk/go/pkg/artifact/pnpm.go
+++ b/sdk/go/pkg/artifact/pnpm.go
@@ -2,6 +2,7 @@ package artifact
 
 import (
 	"fmt"
+	"strings"
 
 	api "github.com/ALT-F4-LLC/vorpal/sdk/go/pkg/api/artifact"
 	"github.com/ALT-F4-LLC/vorpal/sdk/go/pkg/config"
@@ -29,9 +30,16 @@ func Pnpm(context *config.ConfigContext) (*string, error) {
 	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/pnpm-%s-%s", sourceVersion, sourceTarget)
 	source := NewArtifactSource(name, sourcePath).Build()
 
+	var sourceFile string
+	if strings.HasPrefix(sourceTarget, "macos") {
+		sourceFile = fmt.Sprintf("pnpm-%s-%s", sourceVersion, sourceTarget)
+	} else {
+		sourceFile = fmt.Sprintf("pnpm-%s", sourceTarget)
+	}
+
 	stepScript := fmt.Sprintf(`mkdir -p "$VORPAL_OUTPUT/bin"
-cp -p "./source/%s/pnpm-%s-%s" "$VORPAL_OUTPUT/bin/pnpm"
-chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, name, sourceVersion, sourceTarget)
+cp -p "./source/%s/%s" "$VORPAL_OUTPUT/bin/pnpm"
+chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, name, sourceFile)
 
 	step, err := Shell(context, []*string{}, []string{}, stepScript, nil)
 	if err != nil {

--- a/sdk/go/pkg/artifact/pnpm.go
+++ b/sdk/go/pkg/artifact/pnpm.go
@@ -29,16 +29,9 @@ func Pnpm(context *config.ConfigContext) (*string, error) {
 	sourcePath := fmt.Sprintf("https://sdk.vorpal.build/source/pnpm-%s-%s", sourceVersion, sourceTarget)
 	source := NewArtifactSource(name, sourcePath).Build()
 
-	var sourceFile string
-	if sourceTarget == "macos-x64" {
-		sourceFile = fmt.Sprintf("pnpm-%s-%s", sourceVersion, sourceTarget)
-	} else {
-		sourceFile = fmt.Sprintf("pnpm-%s", sourceTarget)
-	}
-
 	stepScript := fmt.Sprintf(`mkdir -p "$VORPAL_OUTPUT/bin"
-cp -p "./source/%s/%s" "$VORPAL_OUTPUT/bin/pnpm"
-chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, name, sourceFile)
+cp -p "./source/%s/pnpm-%s" "$VORPAL_OUTPUT/bin/pnpm"
+chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, name, sourceTarget)
 
 	step, err := Shell(context, []*string{}, []string{}, stepScript, nil)
 	if err != nil {

--- a/sdk/go/pkg/artifact/pnpm.go
+++ b/sdk/go/pkg/artifact/pnpm.go
@@ -30,8 +30,10 @@ func Pnpm(context *config.ConfigContext) (*string, error) {
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	stepScript := fmt.Sprintf(`mkdir -p "$VORPAL_OUTPUT/bin"
+echo "[pnpm-debug] target=%s expected=./source/%s/pnpm-%s"
+ls -la "./source/%s/" || true
 cp -p "./source/%s/pnpm-%s" "$VORPAL_OUTPUT/bin/pnpm"
-chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, name, sourceTarget)
+chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, sourceTarget, name, sourceTarget, name, name, sourceTarget)
 
 	step, err := Shell(context, []*string{}, []string{}, stepScript, nil)
 	if err != nil {

--- a/sdk/go/pkg/artifact/pnpm.go
+++ b/sdk/go/pkg/artifact/pnpm.go
@@ -30,8 +30,8 @@ func Pnpm(context *config.ConfigContext) (*string, error) {
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	stepScript := fmt.Sprintf(`mkdir -p "$VORPAL_OUTPUT/bin"
-cp -p "./source/%s/pnpm-%s" "$VORPAL_OUTPUT/bin/pnpm"
-chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, name, sourceTarget)
+cp -p "./source/%s/pnpm-%s-%s" "$VORPAL_OUTPUT/bin/pnpm"
+chmod +x "$VORPAL_OUTPUT/bin/pnpm"`, name, sourceVersion, sourceTarget)
 
 	step, err := Shell(context, []*string{}, []string{}, stepScript, nil)
 	if err != nil {

--- a/sdk/go/pkg/artifact/pnpm.go
+++ b/sdk/go/pkg/artifact/pnpm.go
@@ -2,7 +2,6 @@ package artifact
 
 import (
 	"fmt"
-	"strings"
 
 	api "github.com/ALT-F4-LLC/vorpal/sdk/go/pkg/api/artifact"
 	"github.com/ALT-F4-LLC/vorpal/sdk/go/pkg/config"
@@ -31,7 +30,7 @@ func Pnpm(context *config.ConfigContext) (*string, error) {
 	source := NewArtifactSource(name, sourcePath).Build()
 
 	var sourceFile string
-	if strings.HasPrefix(sourceTarget, "macos") {
+	if sourceTarget == "macos-x64" {
 		sourceFile = fmt.Sprintf("pnpm-%s-%s", sourceVersion, sourceTarget)
 	} else {
 		sourceFile = fmt.Sprintf("pnpm-%s", sourceTarget)

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "vorpal-sdk"
 repository = "https://github.com/ALT-F4-LLC/vorpal"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 anyhow = { version = "1.0.100" }

--- a/sdk/rust/src/artifact/pnpm.rs
+++ b/sdk/rust/src/artifact/pnpm.rs
@@ -35,6 +35,8 @@ impl Pnpm {
 
         let step_script = formatdoc! {"
             mkdir -p \"$VORPAL_OUTPUT/bin\"
+            echo \"[pnpm-debug] target={source_target} expected=./source/{name}/pnpm-{source_target}\"
+            ls -la \"./source/{name}/\" || true
             cp -p \"./source/{name}/pnpm-{source_target}\" \"$VORPAL_OUTPUT/bin/pnpm\"
             chmod +x \"$VORPAL_OUTPUT/bin/pnpm\""
         };

--- a/sdk/rust/src/artifact/pnpm.rs
+++ b/sdk/rust/src/artifact/pnpm.rs
@@ -33,7 +33,7 @@ impl Pnpm {
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 
-        let source_file = if source_target.starts_with("macos") {
+        let source_file = if source_target == "macos-x64" {
             format!("pnpm-{source_version}-{source_target}")
         } else {
             format!("pnpm-{source_target}")

--- a/sdk/rust/src/artifact/pnpm.rs
+++ b/sdk/rust/src/artifact/pnpm.rs
@@ -35,7 +35,7 @@ impl Pnpm {
 
         let step_script = formatdoc! {"
             mkdir -p \"$VORPAL_OUTPUT/bin\"
-            cp -p \"./source/{name}/pnpm-{source_target}\" \"$VORPAL_OUTPUT/bin/pnpm\"
+            cp -p \"./source/{name}/pnpm-{source_version}-{source_target}\" \"$VORPAL_OUTPUT/bin/pnpm\"
             chmod +x \"$VORPAL_OUTPUT/bin/pnpm\""
         };
 

--- a/sdk/rust/src/artifact/pnpm.rs
+++ b/sdk/rust/src/artifact/pnpm.rs
@@ -33,9 +33,15 @@ impl Pnpm {
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 
+        let source_file = if source_target.starts_with("macos") {
+            format!("pnpm-{source_version}-{source_target}")
+        } else {
+            format!("pnpm-{source_target}")
+        };
+
         let step_script = formatdoc! {"
             mkdir -p \"$VORPAL_OUTPUT/bin\"
-            cp -p \"./source/{name}/pnpm-{source_version}-{source_target}\" \"$VORPAL_OUTPUT/bin/pnpm\"
+            cp -p \"./source/{name}/{source_file}\" \"$VORPAL_OUTPUT/bin/pnpm\"
             chmod +x \"$VORPAL_OUTPUT/bin/pnpm\""
         };
 

--- a/sdk/rust/src/artifact/pnpm.rs
+++ b/sdk/rust/src/artifact/pnpm.rs
@@ -33,15 +33,9 @@ impl Pnpm {
 
         let source = ArtifactSource::new(name, source_path.as_str()).build();
 
-        let source_file = if source_target == "macos-x64" {
-            format!("pnpm-{source_version}-{source_target}")
-        } else {
-            format!("pnpm-{source_target}")
-        };
-
         let step_script = formatdoc! {"
             mkdir -p \"$VORPAL_OUTPUT/bin\"
-            cp -p \"./source/{name}/{source_file}\" \"$VORPAL_OUTPUT/bin/pnpm\"
+            cp -p \"./source/{name}/pnpm-{source_target}\" \"$VORPAL_OUTPUT/bin/pnpm\"
             chmod +x \"$VORPAL_OUTPUT/bin/pnpm\""
         };
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altf4llc/vorpal-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TypeScript SDK for building Vorpal artifacts.",
   "license": "Apache-2.0",
   "repository": {

--- a/sdk/typescript/src/artifact/pnpm.ts
+++ b/sdk/typescript/src/artifact/pnpm.ts
@@ -51,12 +51,8 @@ export class Pnpm {
 
     const source = new ArtifactSource(name, sourcePath).build();
 
-    const sourceFile = sourceTarget === "macos-x64"
-      ? `pnpm-${sourceVersion}-${sourceTarget}`
-      : `pnpm-${sourceTarget}`;
-
     const stepScript = `mkdir -p "$VORPAL_OUTPUT/bin"
-cp -p "./source/${name}/${sourceFile}" "$VORPAL_OUTPUT/bin/pnpm"
+cp -p "./source/${name}/pnpm-${sourceTarget}" "$VORPAL_OUTPUT/bin/pnpm"
 chmod +x "$VORPAL_OUTPUT/bin/pnpm"`;
 
     const steps = [await shell(context, [], [], stepScript, [])];

--- a/sdk/typescript/src/artifact/pnpm.ts
+++ b/sdk/typescript/src/artifact/pnpm.ts
@@ -51,7 +51,7 @@ export class Pnpm {
 
     const source = new ArtifactSource(name, sourcePath).build();
 
-    const sourceFile = sourceTarget.startsWith("macos")
+    const sourceFile = sourceTarget === "macos-x64"
       ? `pnpm-${sourceVersion}-${sourceTarget}`
       : `pnpm-${sourceTarget}`;
 

--- a/sdk/typescript/src/artifact/pnpm.ts
+++ b/sdk/typescript/src/artifact/pnpm.ts
@@ -52,7 +52,7 @@ export class Pnpm {
     const source = new ArtifactSource(name, sourcePath).build();
 
     const stepScript = `mkdir -p "$VORPAL_OUTPUT/bin"
-cp -p "./source/${name}/pnpm-${sourceTarget}" "$VORPAL_OUTPUT/bin/pnpm"
+cp -p "./source/${name}/pnpm-${sourceVersion}-${sourceTarget}" "$VORPAL_OUTPUT/bin/pnpm"
 chmod +x "$VORPAL_OUTPUT/bin/pnpm"`;
 
     const steps = [await shell(context, [], [], stepScript, [])];

--- a/sdk/typescript/src/artifact/pnpm.ts
+++ b/sdk/typescript/src/artifact/pnpm.ts
@@ -51,8 +51,12 @@ export class Pnpm {
 
     const source = new ArtifactSource(name, sourcePath).build();
 
+    const sourceFile = sourceTarget.startsWith("macos")
+      ? `pnpm-${sourceVersion}-${sourceTarget}`
+      : `pnpm-${sourceTarget}`;
+
     const stepScript = `mkdir -p "$VORPAL_OUTPUT/bin"
-cp -p "./source/${name}/pnpm-${sourceVersion}-${sourceTarget}" "$VORPAL_OUTPUT/bin/pnpm"
+cp -p "./source/${name}/${sourceFile}" "$VORPAL_OUTPUT/bin/pnpm"
 chmod +x "$VORPAL_OUTPUT/bin/pnpm"`;
 
     const steps = [await shell(context, [], [], stepScript, [])];

--- a/sdk/typescript/src/artifact/pnpm.ts
+++ b/sdk/typescript/src/artifact/pnpm.ts
@@ -52,6 +52,8 @@ export class Pnpm {
     const source = new ArtifactSource(name, sourcePath).build();
 
     const stepScript = `mkdir -p "$VORPAL_OUTPUT/bin"
+echo "[pnpm-debug] target=${sourceTarget} expected=./source/${name}/pnpm-${sourceTarget}"
+ls -la "./source/${name}/" || true
 cp -p "./source/${name}/pnpm-${sourceTarget}" "$VORPAL_OUTPUT/bin/pnpm"
 chmod +x "$VORPAL_OUTPUT/bin/pnpm"`;
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "website",
   "type": "module",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scripts": {
     "dev": "bun x astro dev",
     "start": "bun x astro dev",

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -41,7 +41,7 @@ The installer accepts the following flags. When piping through `curl`, pass flag
 | Flag | Description |
 |------|-------------|
 | `-y`, `--yes` | Run in non-interactive mode (skip prompts) |
-| `-v`, `--version <ver>` | Version to install (default: `nightly`) |
+| `-v`, `--version <ver>` | Version to install (default: `0.2.2`) |
 | `--services <list>` | Comma-separated services to install (default: `agent,registry,worker`) |
 | `--no-service` | Skip service installation |
 | `--no-path` | Skip PATH configuration |
@@ -58,7 +58,7 @@ curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/main/script/insta
 To install a specific version without starting any services:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/main/script/install.sh | bash -s -- --version v0.2.1 --no-service
+curl -fsSL https://raw.githubusercontent.com/ALT-F4-LLC/vorpal/main/script/install.sh | bash -s -- --version v0.2.2 --no-service
 ```
 
 #### Environment variables
@@ -69,7 +69,7 @@ As an alternative, the installer also accepts environment variables. These are u
 |----------|--------|
 | `VORPAL_NONINTERACTIVE=1` | Enable non-interactive mode |
 | `CI=true` | Enable non-interactive mode |
-| `VORPAL_VERSION=<ver>` | Version to install (default: `0.2.1`) |
+| `VORPAL_VERSION=<ver>` | Version to install (default: `0.2.2`) |
 | `VORPAL_SERVICES=<list>` | Comma-separated services to install (default: `agent,registry,worker`) |
 | `VORPAL_NO_SERVICE=1` | Skip service installation |
 | `VORPAL_NO_PATH=1` | Skip PATH configuration |

--- a/website/src/content/docs/guides/rust.md
+++ b/website/src/content/docs/guides/rust.md
@@ -24,7 +24,7 @@ name = "vorpal"
 path = "src/vorpal.rs"
 
 [dependencies]
-vorpal-sdk = { version = "0.2.1" }
+vorpal-sdk = { version = "0.2.2" }
 anyhow = "1"
 tokio = { features = ["rt-multi-thread"], version = "1" }
 ```


### PR DESCRIPTION
## Summary

- The `cp` step in the `pnpm` artifact's `stepScript` referenced `./source/pnpm/pnpm-{target}`, but the Vorpal agent materializes the downloaded binary using the URL basename — which is `pnpm-{version}-{target}` after the CDN migration in `52de584`. Without this fix, every `pnpm` build fails at the `cp` step on every target.
- Identical one-line fix applied to Go, Rust, and TypeScript SDKs (`./source/{name}/pnpm-{version}-{target}`) so the `cp` source path matches what the agent actually writes to disk.
- Verified across all four targets (aarch64-darwin, aarch64-linux, x86_64-darwin, x86_64-linux): magic-byte signatures fetched from the CDN confirm the binaries route through the URL-basename branch in `cli/src/command/start/agent.rs` (Mach-O for darwin, ELF for linux), which writes the URL basename verbatim with no extension stripping or archive extraction.